### PR TITLE
Update Sabre/HTTP/BasicAuth.php

### DIFF
--- a/Sabre/HTTP/BasicAuth.php
+++ b/Sabre/HTTP/BasicAuth.php
@@ -42,6 +42,16 @@ class Sabre_HTTP_BasicAuth extends Sabre_HTTP_AbstractAuth {
             $auth = $this->httpRequest->getRawServerValue('REDIRECT_HTTP_AUTHORIZATION');
         }
 
+        //if APACHE dont rout the HTTP_AUTHORIZATION falg, use this as rewrite rule:
+        //RewriteRule .* - [E=REMOTE_USER:%{HTTP:Authorization},L]
+        //as rewrite rule for getting user auth on sabre dav side in the correct way
+        if (!$auth) {
+            $auth = $this->httpRequest->getRawServerValue('REMOTE_USER');
+        }    	
+		if (!$auth) {
+            $auth = $this->httpRequest->getRawServerValue('REDIRECT_REMOTE_USER');
+        }
+
         if (!$auth) return false;
 
         if (strpos(strtolower($auth),'basic')!==0) return false;


### PR DESCRIPTION
with this code, the auth rewrite of basic auth can be changed from HTTP_AUTHENTICATIOn to REMOTE_USER for getting the correct value out of the apache and using them on php/onwloud side, if the used host doesnt parse them correctly (occours on simple hosters that dont allow to change apache or php config)
