### PR TITLE
fix for wrong boolean datatypes for postgresql

### DIFF
--- a/MDB2/Driver/Datatype/pgsql.php
+++ b/MDB2/Driver/Datatype/pgsql.php
@@ -312,7 +312,7 @@ class MDB2_Driver_Datatype_pgsql extends MDB2_Driver_Datatype_Common
      */
     function _quoteBoolean($value, $quote, $escape_wildcards)
     {
-        $value = $value ? 't' : 'f';
+        $value = $value ? true : false;
         if (!$quote) {
             return $value;
         }


### PR DESCRIPTION
_quoteBoolean() in MDB2\Driver\Datatype\pgsql.php uses the wrong datatypes for boolean, postgresql takes plain php true/false and not 't' and 'f'.

This very simple patch changes to using true/false. This has silenced a flood of SQL errors on my installation when the owncloud client is synchronizing a folder, errors looks like this:

```
Mar 12 23:50:40 haze postgres[62299]: [3245-1] owncloud@owncloud ERROR:  invalid input syntax for integer: "t" at character 128
Mar 12 23:50:40 haze postgres[62299]: [3245-2] owncloud@owncloud STATEMENT:  EXECUTE mdb2_statement_pgsql_107873275a623ded539b804be4bdd945c9bdfe3d0e (3057, 1362060495, 1362060495, 'httpd/unix-directory', 't', 'httpd', '2016')
Mar 12 23:50:40 haze postgres[62299]: [3299-1] owncloud@owncloud ERROR:  invalid input syntax for integer: "t" at character 129
Mar 12 23:50:40 haze postgres[62299]: [3299-2] owncloud@owncloud STATEMENT:  EXECUTE mdb2_statement_pgsql_10962d031274959bd982864693e7c063c52d41a1db (39230, 1362095114, 1362095114, 'httpd/unix-directory', 't', 'httpd', '1309')
Mar 12 23:50:40 haze postgres[62299]: [3356-1] owncloud@owncloud ERROR:  invalid input syntax for integer: "t" at character 130
Mar 12 23:50:40 haze postgres[62299]: [3356-2] owncloud@owncloud STATEMENT:  EXECUTE mdb2_statement_pgsql_1115ee660eb152fb32eea2862f36f74412f46e1943 (200312, 1362245376, 1362245376, 'httpd/unix-directory', 't', 'httpd', '122')
```

I understand that this is a 3rd party module, hopefully someone can get this upstream or something. Thanks!
