### PR TITLE
Fix database field default value test failure

### DIFF
--- a/MDB2/Schema/Validate.php
+++ b/MDB2/Schema/Validate.php
@@ -384,6 +384,7 @@ class MDB2_Schema_Validate
             }
         }
         if (isset($field['default'])
+            && $field['notnull']
             && PEAR::isError($result = $this->validateDataFieldValue($field, $field['default'], $field_name))
         ) {
             return $this->raiseError(MDB2_SCHEMA_ERROR_VALIDATE,


### PR DESCRIPTION
The automatic upgrade process of owncloud might fail because of the default value test.

The problem is oc_share.expiration witch is DATETIME field with a default NULL value (which is logical for shares without expiration)

The MDB2 third-party app try to validate the null string as a datetime, and fails, and blocks the upgrade.

Fixed by don't test the default value is the field can be NULL.
