### PR TITLE
Add table prefixes support

### DIFF
--- a/MDB2/Schema.php
+++ b/MDB2/Schema.php
@@ -424,10 +424,11 @@ class MDB2_Schema extends PEAR
      * This method can be used if no xml schema file exists yet.
      * The resulting xml schema file may need some manual adjustments.
      *
+     * @param string|null $prefix if not null, only tables with this prefix will be included
      * @return array|MDB2_Error array with definition or error object
      * @access public
      */
-    function getDefinitionFromDatabase()
+    function getDefinitionFromDatabase($prefix = null)
     {
         $database = $this->db->database_name;
         if (empty($database)) {
@@ -471,6 +472,11 @@ class MDB2_Schema extends PEAR
         }
 
         foreach ($tables as $table_name) {
+			$isPrefixMatched = strlen($prefix) && substr($table_name, 0, strlen($prefix)) === $prefix;
+			if (!$isPrefixMatched) {
+				continue;
+			}
+			
             $fields = $this->db->manager->listTableFields($table_name);
             if (PEAR::isError($fields)) {
                 return $fields;


### PR DESCRIPTION
This is needed for **oc_** and  non- **oc_**  tables to live happily in the same DB.
