### PR TITLE
OCI: CLOBs never alter

### DIFF
--- a/MDB2/Driver/Datatype/oci8.php
+++ b/MDB2/Driver/Datatype/oci8.php
@@ -171,6 +171,26 @@ class MDB2_Driver_Datatype_oci8 extends MDB2_Driver_Datatype_Common
     }
 
     // }}}
+    // {{{ _compareCLOBDefinition()
+
+    /**
+     * Obtain an array of changes that may need to applied to an CLOB field
+     *
+     * @param array $current new definition
+     * @param array  $previous old definition
+     * @return array  containing all changes that will need to be applied
+     * @access protected
+     */
+    function _compareCLOBDefinition($current, $previous)
+    {
+		//CLOB definitions only vary in Name, Type and Null, but this is all
+		//dealt with somewhere else
+		//Originally, Common.php would call compareTextDefinition which would
+		//check for Length (and Fixed) which will break Oracle upgrade.
+        return array();
+    }
+
+    // }}}
     // {{{ _quoteCLOB()
 
     /**


### PR DESCRIPTION
@butonic 

This fixes that CLOB fields are automatically marked to alter. The flag is set by https://github.com/owncloud/3rdparty/blob/stable5/MDB2/Driver/Datatype/Common.php#L960 with regard to the Length. It's the text comparison method because it is called from https://github.com/owncloud/3rdparty/blob/stable5/MDB2/Driver/Datatype/Common.php#L987

One note: I did not test what happens when a column is changed from non-clob to clob and vice versa.
