### PR TITLE
Backport upstream patch to quote parameters if they contain a colon

### DIFF
--- a/Sabre/VObject/Parameter.php
+++ b/Sabre/VObject/Parameter.php
@@ -70,7 +70,11 @@ class Parameter extends Node {
             '\,',
         );
 
-        return $this->name . '=' . str_replace($src, $out, $this->value);
+        $value = str_replace($src, $out, $this->value);
+        if (strpos($value,":")!==false) {
+            $value = '"' . $value . '"';
+        }
+        return $this->name . '=' . $value;
 
     }
 


### PR DESCRIPTION
https://github.com/fruux/sabre-vobject/issues/65
https://github.com/owncloud/contacts/issues/214

Both contacts and calendar are affected

@DeepDiver1975 @bartv2 @georgehrke @karlitschek 
