### PR TITLE
smb.php should use sys_get_temp_dir() instead of hard coded /tmp

### DIFF
--- a/smb4php/smb.php
+++ b/smb4php/smb.php
@@ -220,7 +220,7 @@ class smb {
 		switch ($pu['type']) {
 			case 'host':
 				if ($o = smb::look ($pu))
-					$stat = stat ("/tmp");
+					$stat = stat (sys_get_temp_dir());
 				else
 					trigger_error ("url_stat(): list failed for host '{$pu['host']}'", E_USER_WARNING);
 				break;
@@ -230,7 +230,7 @@ class smb {
 					$lshare = strtolower ($pu['share']);  # fix by Eric Leung
 					foreach ($o['disk'] as $s) if ($lshare == strtolower($s)) {
 						$found = TRUE;
-						$stat = stat ("/tmp");
+						$stat = stat (sys_get_temp_dir());
 						break;
 					}
 					if (! $found)
@@ -261,7 +261,7 @@ class smb {
 		$url = rtrim($url, '/');
 		global $__smb_cache;
 		$is_file = (strpos ($info['attr'],'D') === FALSE);
-		$s = ($is_file) ? stat ('/etc/passwd') : stat ('/tmp');
+		$s = ($is_file) ? stat ('/etc/passwd') : stat (sys_get_temp_dir());
 		$s[7] = $s['size'] = $info['size'];
 		$s[8] = $s[9] = $s[10] = $s['atime'] = $s['mtime'] = $s['ctime'] = $info['time'];
 		return $__smb_cache['stat'][$url] = $s;
@@ -429,7 +429,7 @@ class smb_stream_wrapper extends smb {
 			case 'r+':
 			case 'rb':
 			case 'a':
-			case 'a+':  $this->tmpfile = tempnam('/tmp', 'smb.down.');
+			case 'a+':  $this->tmpfile = tempnam(sys_get_temp_dir(), 'smb.down.');
 				smb::execute ('get "'.$pu['path'].'" "'.$this->tmpfile.'"', $pu);
 				break;
 			case 'w':
@@ -437,7 +437,7 @@ class smb_stream_wrapper extends smb {
 			case 'wb':
 			case 'x':
 			case 'x+':  $this->cleardircache();
-				$this->tmpfile = tempnam('/tmp', 'smb.up.');
+				$this->tmpfile = tempnam(sys_get_temp_dir(), 'smb.up.');
 				$this->need_flush=true;
 		}
 		$this->stream = fopen ($this->tmpfile, $mode);


### PR DESCRIPTION
In restricted environments with open_basedir activated, it's necessary to use the configured temp path. /tmp itself is most likely not in open_basedir.
