### PR TITLE
fix directory listing parser in smb.php

### DIFF
--- a/smb4php/smb.php
+++ b/smb4php/smb.php
@@ -159,7 +159,7 @@ class smb {
 					$i = ($mode == 'servers') ? array ($name, "server") : array ($name, "workgroup", $master);
 					break;
 				case 'files':
-					list ($attr, $name) = preg_match ("/^(.*)[ ]+([D|A|H|S|R]+)$/", trim ($regs[1]), $regs2)
+					list ($attr, $name) = preg_match ("/^(.*)[ ]+([D|A|H|N|S|R]+)$/", trim ($regs[1]), $regs2)
 						? array (trim ($regs2[2]), trim ($regs2[1]))
 						: array ('', trim ($regs[1]));
 					list ($his, $im) = array (


### PR DESCRIPTION
As reported in https://github.com/owncloud/core/issues/3441 this patch fixes the appending of "N" to filenames with newer(?) smbclient versions.

Smbclient shows an "N" for some files in the directory listing. So I solved that by adding the "N" to the the pattern in line 162 of smb.php. I've tested file removal and renaming using the web interface and the owncloud client for Linux (1.4.2). No Idea if it could really break other smbclient versions, but I think it shouldn't.

Owncloud version: 5.0.13
Smbclient version: 4.1.3
System: Ubuntu 12.04

Since I can't find out in which version of smbclient the behaviour changed or what the "N" means, more investigation and testing for regressions could be necessary.
