### PR TITLE
Fix SET DEFAULT when there is no default

### DIFF
--- a/doctrine/dbal/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/doctrine/dbal/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -379,7 +379,8 @@ class PostgreSqlPlatform extends AbstractPlatform
             }
 
             if ($columnDiff->hasChanged('default')) {
-                $query = 'ALTER ' . $oldColumnName . ' SET ' . $this->getDefaultValueDeclarationSQL($column->toArray());
+                $defaultStatement = $this->getDefaultValueDeclarationSQL($column->toArray());
+                $query = 'ALTER ' . $oldColumnName . (empty(trim($defaultStatement)) ? ' DROP DEFAULT ' : ' SET ' . $defaultStatement);
                 $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . $query;
             }
 


### PR DESCRIPTION
This is needed when there is no default. Otherwise it generates an empty statement. Bad.
