### PR TITLE
fix drop default on postgresql when default value is removed

### DIFF
--- a/doctrine/dbal/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/doctrine/dbal/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -379,7 +379,9 @@ class PostgreSqlPlatform extends AbstractPlatform
             }
 
             if ($columnDiff->hasChanged('default')) {
-                $query = 'ALTER ' . $oldColumnName . ' SET ' . $this->getDefaultValueDeclarationSQL($column->toArray());
+                $query = 'ALTER ' . $oldColumnName . ((null !== $column->getDefault())
+                       ? ' SET ' . $this->getDefaultValueDeclarationSQL($column->toArray())
+                       : ' DROP DEFAULT');
                 $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . $query;
             }
 


### PR DESCRIPTION
This is a port of https://github.com/doctrine/dbal/pull/44 which was canceled upstream. It solves the migration issues for me becaus it fixes the wrong SQL. A better fix is hopefully created upstream based aon my analysis https://github.com/doctrine/dbal/pull/44#issuecomment-30434221 doctrine developer @deeky666 will have a look.

@karlitschek @kabum @DeepDiver1975 @PVince81 @bartv2 please review.

PS this PR deprecates: https://github.com/owncloud/core/pull/6346 https://github.com/owncloud/apps/pull/1551 as a more general solution
