### PR TITLE
Set back libxml_disable_entity_loader state after use

### DIFF
--- a/PHPExcel/Classes/PHPExcel/Reader/Excel2003XML.php
+++ b/PHPExcel/Classes/PHPExcel/Reader/Excel2003XML.php
@@ -137,8 +137,9 @@ class PHPExcel_Reader_Excel2003XML extends PHPExcel_Reader_Abstract implements P
 
 		$worksheetNames = array();
 
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$xml = simplexml_load_file($pFilename);
+		libxml_disable_entity_loader($loadEntities);
 		$namespaces = $xml->getNamespaces(true);
 
 		$xml_ss = $xml->children($namespaces['ss']);
@@ -166,8 +167,9 @@ class PHPExcel_Reader_Excel2003XML extends PHPExcel_Reader_Abstract implements P
 
 		$worksheetInfo = array();
 
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$xml = simplexml_load_file($pFilename);
+		libxml_disable_entity_loader($loadEntities);
 		$namespaces = $xml->getNamespaces(true);
 
 		$worksheetID = 1;

--- a/PHPExcel/Classes/PHPExcel/Reader/Excel2007.php
+++ b/PHPExcel/Classes/PHPExcel/Reader/Excel2007.php
@@ -92,8 +92,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 		$zip = new ZipArchive;
 		if ($zip->open($pFilename) === true) {
 			// check if it is an OOXML archive
-			libxml_disable_entity_loader(true);
+			$loadEntities = libxml_disable_entity_loader(true);
 			$rels = simplexml_load_string($this->_getFromZipArchive($zip, "_rels/.rels"));
+			libxml_disable_entity_loader($loadEntities);
 			if ($rels !== false) {
 				foreach ($rels->Relationship as $rel) {
 					switch ($rel["Type"]) {
@@ -132,17 +133,19 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 		$zip->open($pFilename);
 
 		//	The files we're looking at here are small enough that simpleXML is more efficient than XMLReader
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$rels = simplexml_load_string(
 		    $this->_getFromZipArchive($zip, "_rels/.rels")
 		); //~ http://schemas.openxmlformats.org/package/2006/relationships");
+		libxml_disable_entity_loader($loadEntities);
 		foreach ($rels->Relationship as $rel) {
 			switch ($rel["Type"]) {
 				case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument":
-				 	libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$xmlWorkbook = simplexml_load_string(
 					    $this->_getFromZipArchive($zip, "{$rel['Target']}")
 					);  //~ http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+					libxml_disable_entity_loader($loadEntities);
 
 					if ($xmlWorkbook->sheets) {
 						foreach ($xmlWorkbook->sheets->sheet as $eleSheet) {
@@ -176,13 +179,15 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 
 		$zip = new ZipArchive;
 		$zip->open($pFilename);
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$rels = simplexml_load_string($this->_getFromZipArchive($zip, "_rels/.rels")); //~ http://schemas.openxmlformats.org/package/2006/relationships");
+		libxml_disable_entity_loader($loadEntities);
 		foreach ($rels->Relationship as $rel) {
 			if ($rel["Type"] == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument") {
 				$dir = dirname($rel["Target"]);
-				libxml_disable_entity_loader(true);
+				$loadEntities = libxml_disable_entity_loader(true);
 				$relsWorkbook = simplexml_load_string($this->_getFromZipArchive($zip, "$dir/_rels/" . basename($rel["Target"]) . ".rels"));  //~ http://schemas.openxmlformats.org/package/2006/relationships");
+				libxml_disable_entity_loader($loadEntities);
 				$relsWorkbook->registerXPathNamespace("rel", "http://schemas.openxmlformats.org/package/2006/relationships");
 
 				$worksheets = array();
@@ -191,8 +196,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 						$worksheets[(string) $ele["Id"]] = $ele["Target"];
 					}
 				}
-				libxml_disable_entity_loader(true);
+				$loadEntities = libxml_disable_entity_loader(true);
 				$xmlWorkbook = simplexml_load_string($this->_getFromZipArchive($zip, "{$rel['Target']}"));  //~ http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+				libxml_disable_entity_loader($loadEntities);
 				if ($xmlWorkbook->sheets) {
 					$dir = dirname($rel["Target"]);
 					foreach ($xmlWorkbook->sheets->sheet as $eleSheet) {
@@ -358,15 +364,17 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 		$zip->open($pFilename);
 
 		//	Read the theme first, because we need the colour scheme when reading the styles
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$wbRels = simplexml_load_string($this->_getFromZipArchive($zip, "xl/_rels/workbook.xml.rels")); //~ http://schemas.openxmlformats.org/package/2006/relationships");
+		libxml_disable_entity_loader($loadEntities);
 		foreach ($wbRels->Relationship as $rel) {
 			switch ($rel["Type"]) {
 				case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme":
 					$themeOrderArray = array('lt1','dk1','lt2','dk2');
 					$themeOrderAdditional = count($themeOrderArray);
-					libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$xmlTheme = simplexml_load_string($this->_getFromZipArchive($zip, "xl/{$rel['Target']}"));
+					libxml_disable_entity_loader($loadEntities);
 					if (is_object($xmlTheme)) {
 						$xmlThemeName = $xmlTheme->attributes();
 						$xmlTheme = $xmlTheme->children("http://schemas.openxmlformats.org/drawingml/2006/main");
@@ -395,13 +403,15 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 					break;
 			}
 		}
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$rels = simplexml_load_string($this->_getFromZipArchive($zip, "_rels/.rels")); //~ http://schemas.openxmlformats.org/package/2006/relationships");
+		libxml_disable_entity_loader($loadEntities);
 		foreach ($rels->Relationship as $rel) {
 			switch ($rel["Type"]) {
 				case "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties":
-					libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$xmlCore = simplexml_load_string($this->_getFromZipArchive($zip, "{$rel['Target']}"));
+					libxml_disable_entity_loader($loadEntities);
 					if (is_object($xmlCore)) {
 						$xmlCore->registerXPathNamespace("dc", "http://purl.org/dc/elements/1.1/");
 						$xmlCore->registerXPathNamespace("dcterms", "http://purl.org/dc/terms/");
@@ -420,8 +430,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 				break;
 
 				case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties":
-					libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$xmlCore = simplexml_load_string($this->_getFromZipArchive($zip, "{$rel['Target']}"));
+					libxml_disable_entity_loader($loadEntities);
 					if (is_object($xmlCore)) {
 						$docProps = $excel->getProperties();
 						if (isset($xmlCore->Company))
@@ -432,8 +443,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 				break;
 
 				case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties":
-					libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$xmlCore = simplexml_load_string($this->_getFromZipArchive($zip, "{$rel['Target']}"));
+					libxml_disable_entity_loader($loadEntities);
 					if (is_object($xmlCore)) {
 						$docProps = $excel->getProperties();
 						foreach ($xmlCore as $xmlProperty) {
@@ -453,14 +465,16 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 
 				case "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument":
 					$dir = dirname($rel["Target"]);
-					libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$relsWorkbook = simplexml_load_string($this->_getFromZipArchive($zip, "$dir/_rels/" . basename($rel["Target"]) . ".rels"));  //~ http://schemas.openxmlformats.org/package/2006/relationships");
+					libxml_disable_entity_loader($loadEntities);
 					$relsWorkbook->registerXPathNamespace("rel", "http://schemas.openxmlformats.org/package/2006/relationships");
 
 					$sharedStrings = array();
 					$xpath = self::array_item($relsWorkbook->xpath("rel:Relationship[@Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings']"));
-					libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$xmlStrings = simplexml_load_string($this->_getFromZipArchive($zip, "$dir/$xpath[Target]"));  //~ http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+					libxml_disable_entity_loader($loadEntities);
 					if (isset($xmlStrings) && isset($xmlStrings->si)) {
 						foreach ($xmlStrings->si as $val) {
 							if (isset($val->t)) {
@@ -481,8 +495,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 					$styles 	= array();
 					$cellStyles = array();
 					$xpath = self::array_item($relsWorkbook->xpath("rel:Relationship[@Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles']"));
-					libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$xmlStyles = simplexml_load_string($this->_getFromZipArchive($zip, "$dir/$xpath[Target]")); //~ http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+					libxml_disable_entity_loader($loadEntities);
 					$numFmts = null;
 					if ($xmlStyles && $xmlStyles->numFmts[0]) {
 						$numFmts = $xmlStyles->numFmts[0];
@@ -579,8 +594,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 							}
 						}
 					}
-					libxml_disable_entity_loader(true);
+					$loadEntities = libxml_disable_entity_loader(true);
 					$xmlWorkbook = simplexml_load_string($this->_getFromZipArchive($zip, "{$rel['Target']}"));  //~ http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+					libxml_disable_entity_loader($loadEntities);
 
 					// Set base date
 					if ($xmlWorkbook->workbookPr) {
@@ -623,8 +639,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 							//		reverse
 							$docSheet->setTitle((string) $eleSheet["name"],false);
 							$fileWorksheet = $worksheets[(string) self::array_item($eleSheet->attributes("http://schemas.openxmlformats.org/officeDocument/2006/relationships"), "id")];
-							libxml_disable_entity_loader(true);
+							$loadEntities = libxml_disable_entity_loader(true);
 							$xmlSheet = simplexml_load_string($this->_getFromZipArchive($zip, "$dir/$fileWorksheet"));  //~ http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+							libxml_disable_entity_loader($loadEntities);
 
 							$sharedFormulas = array();
 
@@ -1206,8 +1223,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 							if (!$this->_readDataOnly) {
 								// Locate hyperlink relations
 								if ($zip->locateName(dirname("$dir/$fileWorksheet") . "/_rels/" . basename($fileWorksheet) . ".rels")) {
-									libxml_disable_entity_loader(true);
+									$loadEntities = libxml_disable_entity_loader(true);
 									$relsWorksheet = simplexml_load_string($this->_getFromZipArchive($zip,  dirname("$dir/$fileWorksheet") . "/_rels/" . basename($fileWorksheet) . ".rels") ); //~ http://schemas.openxmlformats.org/package/2006/relationships");
+									libxml_disable_entity_loader($loadEntities);
 									foreach ($relsWorksheet->Relationship as $ele) {
 										if ($ele["Type"] == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink") {
 											$hyperlinks[(string)$ele["Id"]] = (string)$ele["Target"];
@@ -1248,8 +1266,9 @@ class PHPExcel_Reader_Excel2007 extends PHPExcel_Reader_Abstract implements PHPE
 							if (!$this->_readDataOnly) {
 								// Locate comment relations
 								if ($zip->locateName(dirname("$dir/$fileWorksheet") . "/_rels/" . basename($fileWorksheet) . ".rels")) {
-									libxml_disable_entity_loader(true);									
+									$loadEntities = libxml_disable_entity_loader(true);
 									$relsWorksheet = simplexml_load_string($this->_getFromZipArchive($zip,  dirname("$dir/$fileWorksheet") . "/_rels/" . basename($fileWorksheet) . ".rels") ); //~ http://schemas.openxmlformats.org/package/2006/relationships");
+									libxml_disable_entity_loader($loadEntities);
 									foreach ($relsWorksheet->Relationship as $ele) {
 									    if ($ele["Type"] == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments") {
 											$comments[(string)$ele["Id"]] = (string)$ele["Target"];

--- a/PHPExcel/Classes/PHPExcel/Reader/Gnumeric.php
+++ b/PHPExcel/Classes/PHPExcel/Reader/Gnumeric.php
@@ -243,8 +243,9 @@ class PHPExcel_Reader_Gnumeric extends PHPExcel_Reader_Abstract implements PHPEx
 //		echo htmlentities($gFileData,ENT_QUOTES,'UTF-8');
 //		echo '</pre><hr />';
 //
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$xml = simplexml_load_string($gFileData);
+		libxml_disable_entity_loader($loadEntities);
 		$namespacesMeta = $xml->getNamespaces(true);
 
 //		var_dump($namespacesMeta);

--- a/PHPExcel/Classes/PHPExcel/Reader/OOCalc.php
+++ b/PHPExcel/Classes/PHPExcel/Reader/OOCalc.php
@@ -88,8 +88,9 @@ class PHPExcel_Reader_OOCalc extends PHPExcel_Reader_Abstract implements PHPExce
 			if ($stat && ($stat['size'] <= 255)) {
 				$mimeType = $zip->getFromName($stat['name']);
 			} elseif($stat = $zip->statName('META-INF/manifest.xml')) {
-			libxml_disable_entity_loader(true);
+				$loadEntities = libxml_disable_entity_loader(true);
 		        $xml = simplexml_load_string($zip->getFromName('META-INF/manifest.xml'));
+				libxml_disable_entity_loader($loadEntities);
 		        $namespacesContent = $xml->getNamespaces(true);
 				if (isset($namespacesContent['manifest'])) {
 			        $manifest = $xml->children($namespacesContent['manifest']);
@@ -338,8 +339,9 @@ class PHPExcel_Reader_OOCalc extends PHPExcel_Reader_Abstract implements PHPExce
 		}
 
 //		echo '<h1>Meta Information</h1>';
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$xml = simplexml_load_string($zip->getFromName("meta.xml"));
+		libxml_disable_entity_loader($loadEntities);
 		$namespacesMeta = $xml->getNamespaces(true);
 //		echo '<pre>';
 //		print_r($namespacesMeta);
@@ -423,8 +425,9 @@ class PHPExcel_Reader_OOCalc extends PHPExcel_Reader_Abstract implements PHPExce
 
 
 //		echo '<h1>Workbook Content</h1>';
-		libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 		$xml = simplexml_load_string($zip->getFromName("content.xml"));
+		libxml_disable_entity_loader($loadEntities);
 		$namespacesContent = $xml->getNamespaces(true);
 //		echo '<pre>';
 //		print_r($namespacesContent);

--- a/Sabre/DAV/Client.php
+++ b/Sabre/DAV/Client.php
@@ -529,8 +529,9 @@ class Sabre_DAV_Client {
 
         $body = Sabre_DAV_XMLUtil::convertDAVNamespace($body);
 
-	libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $responseXML = simplexml_load_string($body, null, LIBXML_NOBLANKS | LIBXML_NOCDATA);
+		libxml_disable_entity_loader($loadEntities);
         if ($responseXML===false) {
             throw new InvalidArgumentException('The passed data is not valid XML');
         }

--- a/Sabre/DAV/Locks/Plugin.php
+++ b/Sabre/DAV/Locks/Plugin.php
@@ -618,11 +618,12 @@ class Sabre_DAV_Locks_Plugin extends Sabre_DAV_ServerPlugin {
      * @return Sabre_DAV_Locks_LockInfo
      */
     protected function parseLockRequest($body) {
-	libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $xml = simplexml_load_string(
             Sabre_DAV_XMLUtil::convertDAVNamespace($body),
             null,
             LIBXML_NOWARNING);
+		libxml_disable_entity_loader($loadEntities);
         $xml->registerXPathNamespace('d','urn:DAV');
         $lockInfo = new Sabre_DAV_Locks_LockInfo();
 

--- a/Sabre/DAV/XMLUtil.php
+++ b/Sabre/DAV/XMLUtil.php
@@ -113,7 +113,7 @@ class Sabre_DAV_XMLUtil {
 
         // Retaining old error setting
         $oldErrorSetting =  libxml_use_internal_errors(true);
-	libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 
         // Clearing any previous errors
         libxml_clear_errors();
@@ -124,6 +124,7 @@ class Sabre_DAV_XMLUtil {
         $dom->preserveWhiteSpace = false;
         
         $dom->loadXML(self::convertDAVNamespace($xml),LIBXML_NOWARNING | LIBXML_NOERROR | LIBXML_DTDLOAD | LIBXML_DTDATTR);
+		libxml_disable_entity_loader($loadEntities);
 
         if ($error = libxml_get_last_error()) {
             libxml_clear_errors();

--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -521,8 +521,9 @@ class getid3_lib
 	public static function XML2array($XMLstring) {
 		if (function_exists('simplexml_load_string')) {
 			if (function_exists('get_object_vars')) {
-				libxml_disable_entity_loader(true);
+				$loadEntities = libxml_disable_entity_loader(true);
 				$XMLobject = simplexml_load_string($XMLstring);
+				libxml_disable_entity_loader($loadEntities);
 				return self::SimpleXMLelement2array($XMLobject);
 			}
 		}

--- a/phpdocx/classes/CreateDocx.inc
+++ b/phpdocx/classes/CreateDocx.inc
@@ -1229,8 +1229,9 @@ class CreateDocx extends CreateDocument
             PhpdocxLogger::logger($e->getMessage(), 'fatal');
         }
         $baseDocument = new DOMDocument();
-	libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $baseDocument->loadXML($baseTemplateDocumentT);
+		libxml_disable_entity_loader($loadEntities);
         $docXpath = new DOMXPath($baseDocument);
         $docXpath->registerNamespace('w', 'http://schemas.openxmlformats.org/wordprocessingml/2006/main');
         $queryDoc = '//w:body/w:sdt';
@@ -1265,8 +1266,9 @@ class CreateDocx extends CreateDocument
             PhpdocxLogger::logger($e->getMessage(), 'fatal');
         }
         $this->_contentTypeT = new DOMDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $this->_contentTypeT->loadXML($baseTemplateContentTypeT);
+		libxml_disable_entity_loader($loadEntities);
 
         //We are going to include the standard image defaults
 
@@ -1289,8 +1291,9 @@ class CreateDocx extends CreateDocument
         }
 
         $this->_wordRelsDocumentRelsT = new DOMDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $this->_wordRelsDocumentRelsT->loadXML($baseTemplateDocumentRelsT);
+		libxml_disable_entity_loader($loadEntities);
         $relationships = $this->_wordRelsDocumentRelsT->getElementsByTagName('Relationship');
 
         //Now we have to take care of the case that the template used is not one of the default preprocessed templates
@@ -2307,10 +2310,11 @@ class CreateDocx extends CreateDocument
         if ($this->_debug->getActive() == 1) {
             PhpdocxLogger::logger('Debug is active, add messages to objDebug.', 'debug');
             libxml_use_internal_errors(true);
-            libxml_disable_entity_loader(true);
+			$loadEntities = libxml_disable_entity_loader(true);
             simplexml_load_string(
                 $this->_wordDocumentT, 'SimpleXMLElement', LIBXML_NOWARNING
-            );
+			);
+			libxml_disable_entity_loader($loadEntities);
             $xmlErrors = libxml_get_errors();
             if (is_array($xmlErrors)) {
                 $this->_debug->addMessage($xmlErrors);
@@ -2452,8 +2456,9 @@ class CreateDocx extends CreateDocument
             }
         //let's parse the different styles via XPath
         $newStylesDoc = new DOMDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $newStylesDoc->loadXML($newStyles);
+		libxml_disable_entity_loader($loadEntities);
         $stylesXpath = new DOMXPath($newStylesDoc);
         $stylesXpath->registerNamespace('w', 'http://schemas.openxmlformats.org/wordprocessingml/2006/main');
         $queryStyle = '//w:style';
@@ -2473,8 +2478,9 @@ class CreateDocx extends CreateDocument
             PhpdocxLogger::logger($e->getMessage(), 'fatal');
         }
         $stylesDocument = new DomDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $stylesDocument->loadXML($this->_wordStylesT);
+		libxml_disable_entity_loader($loadEntities);
         $baseNode = $stylesDocument->documentElement;
         $stylesDocumentXPath = new DOMXPath($stylesDocument);
         $stylesDocumentXPath->registerNamespace('w', 'http://schemas.openxmlformats.org/wordprocessingml/2006/main');
@@ -2657,8 +2663,9 @@ class CreateDocx extends CreateDocument
             PhpdocxLogger::logger($e->getMessage(), 'fatal');
         }
         $stylesDocument = new DomDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $stylesDocument->loadXML($this->_wordStylesT);
+		libxml_disable_entity_loader($loadEntities);
         $langNode = $stylesDocument->getElementsByTagName('lang');
         $langNode->item(0)->setAttribute('w:val', $lang);
         $langNode->item(0)->setAttribute('w:eastAsia', $lang);
@@ -2711,8 +2718,9 @@ class CreateDocx extends CreateDocument
     {
 
         $templateStylesheet = new DomDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $templateStylesheet->loadXML($templateStyles);
+		libxml_disable_entity_loader($loadEntities);
         //let's parse the different styles via XPath
 
         $stylesXpath = new DOMXPath($importedStylesheet);
@@ -2722,8 +2730,9 @@ class CreateDocx extends CreateDocument
 
         //Let's get the original styles as a DOMNode
         $stylesDocument = new DomDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $stylesDocument->loadXML($templateStyles);
+		libxml_disable_entity_loader($loadEntities);
         $baseNode = $stylesDocument->documentElement;
 
         //Now we start to insert the new styles at the end of the styles.xml
@@ -3037,8 +3046,9 @@ class CreateDocx extends CreateDocument
         }
 
         $this->_wordSettingsT = new DOMDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $this->_wordSettingsT->loadXML($baseTemplateSettingsT);
+		libxml_disable_entity_loader($loadEntities);
         $selectedElements = $this->_wordSettingsT->documentElement->getElementsByTagName($tag);
         if($selectedElements->length == 0){
             $settingsElement = $this->_wordSettingsT->createDocumentFragment();
@@ -3713,8 +3723,9 @@ class CreateDocx extends CreateDocument
         }
 
         $settingsDoc = new DOMDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $settingsDoc->loadXML($baseSettings);
+		libxml_disable_entity_loader($loadEntities);
         $settings = $settingsDoc->documentElement;
 
         foreach($data as $key => $value){

--- a/phpdocx/classes/CreateMath.inc
+++ b/phpdocx/classes/CreateMath.inc
@@ -125,8 +125,9 @@ class CreateMath extends CreateElement
         $mathML = str_replace($arrDeleteStrsMML, $arrDeleteToStrsMML, $mathML);
 
         $rscXML = new DOMDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $rscXML->loadXML($mathML);
+		libxml_disable_entity_loader($loadEntities);
         $objXSLTProc = new XSLTProcessor();
         $objXSL = new DOMDocument();
         $objXSL->load('../xsl/MML2OMML_n.XSL');

--- a/phpdocx/classes/Docx2Text.inc
+++ b/phpdocx/classes/Docx2Text.inc
@@ -222,8 +222,9 @@ class Docx2Text
         }
 
         $this->domDocument = new DomDocument();
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $this->domDocument->loadXML($this->_document);
+		libxml_disable_entity_loader($loadEntities);
         //get the body node to check the content from all his children
         $bodyNode = $this->domDocument->getElementsByTagNameNS('http://schemas.openxmlformats.org/wordprocessingml/2006/main', 'body');
         //We get the body node. it is known that there is only one body tag
@@ -322,8 +323,9 @@ class Docx2Text
             }
             if (!empty($this->_endnote)) {
                 $domDocument = new DomDocument();
-        	libxml_disable_entity_loader(true);
+				$loadEntities = libxml_disable_entity_loader(true);
                 $domDocument->loadXML($this->_endnote);
+				libxml_disable_entity_loader($loadEntities);
                 $endnotes = $domDocument->getElementsByTagNameNS('http://schemas.openxmlformats.org/wordprocessingml/2006/main', 'endnote');
                 foreach ($endnotes as $endnote) {
                     $xml = $endnote->ownerDocument->saveXML($endnote);
@@ -346,8 +348,9 @@ class Docx2Text
             }
             if (!empty($this->_footnote)) {
                 $domDocument = new DomDocument();
-		libxml_disable_entity_loader(true);
+				$loadEntities = libxml_disable_entity_loader(true);
                 $domDocument->loadXML($this->_footnote);
+				libxml_disable_entity_loader($loadEntities);
                 $footnotes = $domDocument->getElementsByTagNameNS('http://schemas.openxmlformats.org/wordprocessingml/2006/main', 'footnote');
                 foreach ($footnotes as $footnote) {
                     $xml = $footnote->ownerDocument->saveXML( $footnote );
@@ -371,8 +374,9 @@ class Docx2Text
         if(!empty($this->_numbering)){
             //we use the domdocument to iterate the children of the numbering tag 
             $domDocument = new DomDocument();
-            libxml_disable_entity_loader(true);
+			$loadEntities = libxml_disable_entity_loader(true);
             $domDocument->loadXML($this->_numbering);
+			libxml_disable_entity_loader($loadEntities);
             $numberings = $domDocument->getElementsByTagNameNS('http://schemas.openxmlformats.org/wordprocessingml/2006/main', 'numbering');
             //there is only one numbering tag in the numbering.xml
             $numberings = $numberings->item(0);
@@ -422,8 +426,9 @@ class Docx2Text
                 $this->_relations = $this->docx->getFromName('word/_rels/document.xml.rels');
             }
             $domDocument = new DomDocument();
-            libxml_disable_entity_loader(true);
+			$loadEntities = libxml_disable_entity_loader(true);
             $domDocument->loadXML($this->_relations);
+			libxml_disable_entity_loader($loadEntities);
             $relations = $domDocument->getElementsByTagName('Relationships');
             $relations = $relations->item(0);
             foreach ($relations->childNodes as $relation) {

--- a/phpdocx/classes/TransformDoc.inc
+++ b/phpdocx/classes/TransformDoc.inc
@@ -241,10 +241,11 @@ class TransformDoc
             echo 'Unable to find the DOCX file';
             exit();
         }
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $relations = simplexml_load_string(
             $package->getFromName('_rels/.rels')
         );
+		libxml_disable_entity_loader($loadEntities);
 
         foreach ($relations->Relationship as $rel) {
             if ($rel["Type"] == TransformDoc::SCHEMA_OFFICEDOCUMENT) {
@@ -260,8 +261,9 @@ class TransformDoc
                 $xml = preg_replace(
                     '/(<w:wordDocument)+(.)*(><w:body>)/', '<w:body>', $xml
                 );
-        	libxml_disable_entity_loader(true);
+				$loadEntities = libxml_disable_entity_loader(true);
                 @$xmlDOM->loadXML($xml);
+				libxml_disable_entity_loader($loadEntities);
                 $xsl = new DOMDocument();
                 $xsl->load(dirname(__FILE__) . '/../xsl/docx2html.xsl');
 
@@ -283,10 +285,11 @@ class TransformDoc
                 $idImgs[] = substr($datFiltered[1], 0, -1);
             }
         }
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $relationsImgs = simplexml_load_string(
             $package->getFromName('word/_rels/document.xml.rels')
         );
+		libxml_disable_entity_loader($loadEntities);
         $pathImgs = array();
         foreach ($relationsImgs->Relationship as $relImg) {
             if ($relImg["Type"] == TransformDoc::SCHEMA_IMAGEDOCUMENT) {
@@ -370,8 +373,9 @@ class TransformDoc
     private function _extractProps()
     {
         $xmlDOM = new DOMDocument();
-	libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $xmlDOM->loadXML($this->getDocument());
+		libxml_disable_entity_loader($loadEntities);
         //Get the page size and orientation
         $node = $xmlDOM->getElementsByTagName('pgSz');
         $docProps = array();

--- a/phpdocx/classes/WordML.inc
+++ b/phpdocx/classes/WordML.inc
@@ -96,8 +96,9 @@ class WordML extends CreateElement
         $namespaces = 'xmlns:ve="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" ';
         $wordML = '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><w:root '.$namespaces.'>'.$this->_wordML;
         $wordML = $wordML.'</w:root>';
-        libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $wordMLChunk->loadXML($wordML);
+		libxml_disable_entity_loader($loadEntities);
         $wordMLXpath = new DOMXPath($wordMLChunk);
         $wordMLXpath->registerNamespace('w', 'http://schemas.openxmlformats.org/wordprocessingml/2006/main');
         $query= '//w:r';


### PR DESCRIPTION
@LukasReschke @karlitschek as discussed: setting back the entity loader state after disabling.
