### PR TITLE
Set back libxml_disable_entity_loader state after use

### DIFF
--- a/Sabre/DAV/Client.php
+++ b/Sabre/DAV/Client.php
@@ -529,8 +529,9 @@ class Sabre_DAV_Client {
 
         $body = Sabre_DAV_XMLUtil::convertDAVNamespace($body);
 
-	libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $responseXML = simplexml_load_string($body, null, LIBXML_NOBLANKS | LIBXML_NOCDATA);
+		libxml_disable_entity_loader($loadEntities);
         if ($responseXML===false) {
             throw new InvalidArgumentException('The passed data is not valid XML');
         }

--- a/Sabre/DAV/Locks/Plugin.php
+++ b/Sabre/DAV/Locks/Plugin.php
@@ -618,11 +618,12 @@ class Sabre_DAV_Locks_Plugin extends Sabre_DAV_ServerPlugin {
      * @return Sabre_DAV_Locks_LockInfo
      */
     protected function parseLockRequest($body) {
-	libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
         $xml = simplexml_load_string(
             Sabre_DAV_XMLUtil::convertDAVNamespace($body),
             null,
             LIBXML_NOWARNING);
+		libxml_disable_entity_loader($loadEntities);
         $xml->registerXPathNamespace('d','urn:DAV');
         $lockInfo = new Sabre_DAV_Locks_LockInfo();
 

--- a/Sabre/DAV/XMLUtil.php
+++ b/Sabre/DAV/XMLUtil.php
@@ -113,7 +113,7 @@ class Sabre_DAV_XMLUtil {
 
         // Retaining old error setting
         $oldErrorSetting =  libxml_use_internal_errors(true);
-	libxml_disable_entity_loader(true);
+		$loadEntities = libxml_disable_entity_loader(true);
 
         // Clearing any previous errors
         libxml_clear_errors();
@@ -124,6 +124,7 @@ class Sabre_DAV_XMLUtil {
         $dom->preserveWhiteSpace = false;
         
         $dom->loadXML(self::convertDAVNamespace($xml),LIBXML_NOWARNING | LIBXML_NOERROR | LIBXML_DTDLOAD | LIBXML_DTDATTR);
+		libxml_disable_entity_loader($loadEntities);
 
         if ($error = libxml_get_last_error()) {
             libxml_clear_errors();

--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -523,8 +523,9 @@ class getid3_lib
 	static function XML2array($XMLstring) {
 		if (function_exists('simplexml_load_string')) {
 			if (function_exists('get_object_vars')) {
-				libxml_disable_entity_loader(true);
+				$loadEntities = libxml_disable_entity_loader(true);
 				$XMLobject = simplexml_load_string($XMLstring);
+				libxml_disable_entity_loader($loadEntities);
 				return self::SimpleXMLelement2array($XMLobject);
 			}
 		}


### PR DESCRIPTION
Backport of https://github.com/owncloud/3rdparty/pull/78 to stable5.

It's basically the same fix without the preview libraries which didn't exist in stable5 (no thumbnails)

@karlitschek @LukasReschke @schiesbn 
