### PR TITLE
Fix escaping of column name for specific alter table case

### DIFF
--- a/doctrine/dbal/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/doctrine/dbal/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -411,7 +411,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             }
 
             if ($columnDiff->hasChanged('length')) {
-                $query = 'ALTER ' . $column->getName() . ' TYPE ' . $column->getType()->getSqlDeclaration($column->toArray(), $this);
+                $query = 'ALTER ' . $oldColumnName . ' TYPE ' . $column->getType()->getSqlDeclaration($column->toArray(), $this);
                 $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . $query;
             }
         }

--- a/patches.txt
+++ b/patches.txt
@@ -2,3 +2,4 @@ Patches:
 
 - remove dompdf from phpdocx, because we already ship dompdf in the 3rdparty's root folder (see 3ae4904 and e1e3207)
 - some external entity patches from https://github.com/owncloud/3rdparty/pull/74 - they should get superseeded by updating the affected libraries.
+- Doctrine: fix postgres column escaping when using reserved keyword: https://github.com/doctrine/dbal/pull/627


### PR DESCRIPTION
When changing the length of a field, the column name needs to be escaped
properly in postgres.

Fixes https://github.com/owncloud/core/issues/9318
