### PR TITLE
Replace fpassthru() as it can cause issues with large files on some systems (even 64bit)

### DIFF
--- a/Sabre/HTTP/Response.php
+++ b/Sabre/HTTP/Response.php
@@ -159,7 +159,7 @@ class Sabre_HTTP_Response {
 
         if (is_resource($body)) {
 
-            fpassthru($body);
+            file_put_contents('php://output', $body);
 
         } else {
 

--- a/patches.txt
+++ b/patches.txt
@@ -1,4 +1,5 @@
 Patches:
 
+- Sabre: replaced fpassthru due to large file issues (https://github.com/owncloud/core/issues/8578#issuecomment-49812124)
 - remove dompdf from phpdocx, because we already ship dompdf in the 3rdparty's root folder (see 3ae4904 and e1e3207)
 - some external entity patches from https://github.com/owncloud/3rdparty/pull/74 - they should get superseeded by updating the affected libraries.


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/8578
See https://github.com/owncloud/core/issues/8578#issuecomment-49812124

Partial port of https://github.com/fruux/sabre-dav/commit/52fb4a5f986466c3530af4d71e5c5a68e430efd7#diff-125bd7a16c07243283501c89f7127dfdL162.
