### PR TITLE
Bump pear/archive_tar to v1.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"bantu/ini-get-wrapper": "v1.0.1",
 		"natxet/CssMin": "dev-master",
 		"punic/punic": "1.1.0",
-		"pear/archive_tar": "~1.4",
+		"pear/archive_tar": "1.4.1",
 		"patchwork/utf8": "~1.1",
 		"symfony/console": "2.6.4",
 		"symfony/event-dispatcher": "2.6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9951c5b80f0a2db39bf58226d34d7a0e",
-    "content-hash": "c34d1727eda3debbb5821cda49dfd44e",
+    "hash": "073a86270c182240599fd7931c4dba77",
+    "content-hash": "2f227b189681e5c9a0911df84ca4a5f4",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1630,21 +1630,21 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "e337c40bf467a1fcde6b770fce8ca6dc32dcc38f"
+                "reference": "fc2937c0e5a2a1c62a378d16394893172f970064"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/e337c40bf467a1fcde6b770fce8ca6dc32dcc38f",
-                "reference": "e337c40bf467a1fcde6b770fce8ca6dc32dcc38f",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/fc2937c0e5a2a1c62a378d16394893172f970064",
+                "reference": "fc2937c0e5a2a1c62a378d16394893172f970064",
                 "shasum": ""
             },
             "require": {
-                "pear/pear-core-minimal": "^1.9.5",
-                "php": ">=4.3.0"
+                "pear/pear-core-minimal": "^1.10.0alpha2",
+                "php": ">=5.2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "*"
@@ -1692,7 +1692,7 @@
                 "archive",
                 "tar"
             ],
-            "time": "2015-07-20 07:52:03"
+            "time": "2015-08-05 12:31:03"
         },
         {
             "name": "pear/console_getopt",

--- a/composer/include_paths.php
+++ b/composer/include_paths.php
@@ -8,7 +8,7 @@ $baseDir = $vendorDir;
 return array(
     $vendorDir . '/phpseclib/phpseclib/phpseclib',
     $vendorDir . '/pear/console_getopt',
-    $vendorDir . '/pear/archive_tar',
     $vendorDir . '/pear/pear_exception',
     $vendorDir . '/pear/pear-core-minimal/src',
+    $vendorDir . '/pear/archive_tar',
 );

--- a/composer/installed.json
+++ b/composer/installed.json
@@ -1915,74 +1915,6 @@
         "description": "More info available on: http://pear.php.net/package/Console_Getopt"
     },
     {
-        "name": "pear/archive_tar",
-        "version": "1.4.0",
-        "version_normalized": "1.4.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/pear/Archive_Tar.git",
-            "reference": "e337c40bf467a1fcde6b770fce8ca6dc32dcc38f"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/e337c40bf467a1fcde6b770fce8ca6dc32dcc38f",
-            "reference": "e337c40bf467a1fcde6b770fce8ca6dc32dcc38f",
-            "shasum": ""
-        },
-        "require": {
-            "pear/pear-core-minimal": "^1.9.5",
-            "php": ">=4.3.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "*"
-        },
-        "suggest": {
-            "ext-bz2": "bz2 compression support.",
-            "ext-xz": "lzma2 compression support.",
-            "ext-zlib": "Gzip compression support."
-        },
-        "time": "2015-07-20 07:52:03",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.4.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-0": {
-                "Archive_Tar": ""
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "include-path": [
-            "./"
-        ],
-        "license": [
-            "BSD-3-Clause"
-        ],
-        "authors": [
-            {
-                "name": "Vincent Blavet",
-                "email": "vincent@phpconcept.net"
-            },
-            {
-                "name": "Greg Beaver",
-                "email": "greg@chiaraquartet.net"
-            },
-            {
-                "name": "Michiel Rook",
-                "email": "mrook@php.net"
-            }
-        ],
-        "description": "Tar file management class",
-        "homepage": "https://github.com/pear/Archive_Tar",
-        "keywords": [
-            "archive",
-            "tar"
-        ]
-    },
-    {
         "name": "pear/pear_exception",
         "version": "v1.0.0",
         "version_normalized": "1.0.0.0",
@@ -2745,6 +2677,74 @@
             "assets",
             "compression",
             "minification"
+        ]
+    },
+    {
+        "name": "pear/archive_tar",
+        "version": "1.4.1",
+        "version_normalized": "1.4.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/pear/Archive_Tar.git",
+            "reference": "fc2937c0e5a2a1c62a378d16394893172f970064"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/fc2937c0e5a2a1c62a378d16394893172f970064",
+            "reference": "fc2937c0e5a2a1c62a378d16394893172f970064",
+            "shasum": ""
+        },
+        "require": {
+            "pear/pear-core-minimal": "^1.10.0alpha2",
+            "php": ">=5.2.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "*"
+        },
+        "suggest": {
+            "ext-bz2": "bz2 compression support.",
+            "ext-xz": "lzma2 compression support.",
+            "ext-zlib": "Gzip compression support."
+        },
+        "time": "2015-08-05 12:31:03",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.4.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-0": {
+                "Archive_Tar": ""
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "include-path": [
+            "./"
+        ],
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Vincent Blavet",
+                "email": "vincent@phpconcept.net"
+            },
+            {
+                "name": "Greg Beaver",
+                "email": "greg@chiaraquartet.net"
+            },
+            {
+                "name": "Michiel Rook",
+                "email": "mrook@php.net"
+            }
+        ],
+        "description": "Tar file management class",
+        "homepage": "https://github.com/pear/Archive_Tar",
+        "keywords": [
+            "archive",
+            "tar"
         ]
     }
 ]

--- a/pear/archive_tar/composer.json
+++ b/pear/archive_tar/composer.json
@@ -23,8 +23,8 @@
         }
     ],
     "require": {
-        "php": ">=4.3.0",
-        "pear/pear-core-minimal": "^1.9.5"
+        "php": ">=5.2.0",
+        "pear/pear-core-minimal": "^1.10.0alpha2"
     },
     "suggest": {
         "ext-zlib": "Gzip compression support.",


### PR DESCRIPTION
Trivial bump. Basically just updating dependencie list (dropping PHP4 support)