### PR TITLE
Track ^v1.0 of the lognormalizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"guzzlehttp/guzzle": "5.3.0",
 		"league/flysystem": "1.0.4",
 		"pear/pear-core-minimal": "v1.10.1",
-		"interfasys/lognormalizer": "dev-master@dev",
+		"interfasys/lognormalizer": "^v1.0",
 		"deepdiver1975/TarStreamer": "v0.1-beta3",
 		"patchwork/jsqueeze": "^2.0",
 		"kriswallsmith/assetic": "1.3.2",


### PR DESCRIPTION
There is zero change with the current version, the version number is just there to indicate that it's stable.