### PR TITLE
Patchwork workarounds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"natxet/CssMin": "dev-master",
 		"punic/punic": "1.6.3",
 		"pear/archive_tar": "1.4.1",
-		"patchwork/utf8": "1.2.5",
+		"patchwork/utf8": "1.2.6",
 		"symfony/console": "2.8.1",
 		"symfony/event-dispatcher": "2.8.1",
 		"symfony/routing": "2.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "535817718a4310cc78be6e0ba74eef38",
-    "content-hash": "4bfd282c4d64796696f153ce27f1b62b",
+    "hash": "38f085368014c38a315ea4c53ce531de",
+    "content-hash": "bd2122818a7f85e08f1b7362eeb91b6e",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1621,16 +1621,16 @@
         },
         {
             "name": "patchwork/utf8",
-            "version": "v1.2.5",
+            "version": "v1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tchwork/utf8.git",
-                "reference": "25a55c6c668de61cc3b97aab4237ebf6dadabe17"
+                "reference": "f986d18f4e37ab70b792e977c7d85970cf84f164"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tchwork/utf8/zipball/25a55c6c668de61cc3b97aab4237ebf6dadabe17",
-                "reference": "25a55c6c668de61cc3b97aab4237ebf6dadabe17",
+                "url": "https://api.github.com/repos/tchwork/utf8/zipball/f986d18f4e37ab70b792e977c7d85970cf84f164",
+                "reference": "f986d18f4e37ab70b792e977c7d85970cf84f164",
                 "shasum": ""
             },
             "require": {
@@ -1676,7 +1676,7 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2015-10-14 08:58:12"
+            "time": "2015-12-15 15:33:41"
         },
         {
             "name": "pear/archive_tar",

--- a/composer/installed.json
+++ b/composer/installed.json
@@ -1223,67 +1223,6 @@
         ]
     },
     {
-        "name": "patchwork/utf8",
-        "version": "v1.2.5",
-        "version_normalized": "1.2.5.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/tchwork/utf8.git",
-            "reference": "25a55c6c668de61cc3b97aab4237ebf6dadabe17"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/tchwork/utf8/zipball/25a55c6c668de61cc3b97aab4237ebf6dadabe17",
-            "reference": "25a55c6c668de61cc3b97aab4237ebf6dadabe17",
-            "shasum": ""
-        },
-        "require": {
-            "lib-pcre": ">=7.3",
-            "php": ">=5.3.0"
-        },
-        "suggest": {
-            "ext-iconv": "Use iconv for best performance",
-            "ext-intl": "Use Intl for best performance",
-            "ext-mbstring": "Use Mbstring for best performance",
-            "ext-wfio": "Use WFIO for UTF-8 filesystem access on Windows"
-        },
-        "time": "2015-10-14 08:58:12",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.2-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Patchwork\\": "src/Patchwork/"
-            },
-            "classmap": [
-                "src/Normalizer.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "(Apache-2.0 or GPL-2.0)"
-        ],
-        "authors": [
-            {
-                "name": "Nicolas Grekas",
-                "email": "p@tchwork.com"
-            }
-        ],
-        "description": "Portable and performant UTF-8, Unicode and Grapheme Clusters for PHP",
-        "homepage": "https://github.com/tchwork/utf8",
-        "keywords": [
-            "grapheme",
-            "i18n",
-            "unicode",
-            "utf-8",
-            "utf8"
-        ]
-    },
-    {
         "name": "phpseclib/phpseclib",
         "version": "2.0.0",
         "version_normalized": "2.0.0.0",
@@ -3236,6 +3175,67 @@
             "php",
             "stream",
             "tar"
+        ]
+    },
+    {
+        "name": "patchwork/utf8",
+        "version": "v1.2.6",
+        "version_normalized": "1.2.6.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/tchwork/utf8.git",
+            "reference": "f986d18f4e37ab70b792e977c7d85970cf84f164"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/tchwork/utf8/zipball/f986d18f4e37ab70b792e977c7d85970cf84f164",
+            "reference": "f986d18f4e37ab70b792e977c7d85970cf84f164",
+            "shasum": ""
+        },
+        "require": {
+            "lib-pcre": ">=7.3",
+            "php": ">=5.3.0"
+        },
+        "suggest": {
+            "ext-iconv": "Use iconv for best performance",
+            "ext-intl": "Use Intl for best performance",
+            "ext-mbstring": "Use Mbstring for best performance",
+            "ext-wfio": "Use WFIO for UTF-8 filesystem access on Windows"
+        },
+        "time": "2015-12-15 15:33:41",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.2-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Patchwork\\": "src/Patchwork/"
+            },
+            "classmap": [
+                "src/Normalizer.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "(Apache-2.0 or GPL-2.0)"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            }
+        ],
+        "description": "Portable and performant UTF-8, Unicode and Grapheme Clusters for PHP",
+        "homepage": "https://github.com/tchwork/utf8",
+        "keywords": [
+            "grapheme",
+            "i18n",
+            "unicode",
+            "utf-8",
+            "utf8"
         ]
     }
 ]

--- a/patches.txt
+++ b/patches.txt
@@ -1,5 +1,4 @@
 Patches:
 
-- remove dompdf from phpdocx, because we already ship dompdf in the 3rdparty's root folder (see 3ae4904 and e1e3207)
-- some external entity patches from https://github.com/owncloud/3rdparty/pull/74 - they should get superseeded by updating the affected libraries.
 - Doctrine: fix postgres column escaping when using reserved keyword: https://github.com/doctrine/dbal/pull/627
+- patchwork/utf8: Remove trigger_error() that spammed the error log

--- a/patchwork/utf8/CHANGELOG.md
+++ b/patchwork/utf8/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.2.6 (2015-12-15)
+
+- fix compat with symfony-polyfill
+
 ## v1.2.5 (2015-10-14)
 
 - handle the third argument of mb_convert_encoding() being an array
@@ -40,6 +44,14 @@
 
 - add best-fit mappings for UTF-8 to Code Page approximations
 - add portable Unicode filesystem access under Windows and other OSes
+
+## v1.1.31 (2015-12-15)
+
+- fix compat with symfony-polyfill
+
+## v1.1.30 (2015-06-29)
+
+- fix mb_strrpos shim with negative offset
 
 ## v1.1.29 (2015-04-26)
 

--- a/patchwork/utf8/src/Patchwork/Utf8/Bootup.php
+++ b/patchwork/utf8/src/Patchwork/Utf8/Bootup.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2013 Nicolas Grekas - p@tchwork.com
+ * Copyright (C) 2016 Nicolas Grekas - p@tchwork.com
  *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the (at your option):
@@ -66,7 +66,7 @@ class Bootup
             if (!in_array(strtolower(mb_language()), array('uni', 'neutral'))) {
                 mb_language('uni');
             }
-        } elseif (!defined('MB_OVERLOAD_MAIL')) {
+        } elseif (!function_exists('mb_strlen')) {
             extension_loaded('iconv') or static::initIconv();
 
             require __DIR__.'/Bootup/mbstring.php';
@@ -87,7 +87,7 @@ class Bootup
             if ('UTF-8' !== strtoupper(iconv_get_encoding('output_encoding'))) {
                 iconv_set_encoding('output_encoding', 'UTF-8');
             }
-        } elseif (!defined('ICONV_IMPL')) {
+        } elseif (!function_exists('iconv')) {
             require __DIR__.'/Bootup/iconv.php';
         }
     }
@@ -113,7 +113,7 @@ class Bootup
 
         define('GRAPHEME_CLUSTER_RX', PCRE_VERSION >= '8.32' ? '\X' : s\Intl::GRAPHEME_CLUSTER_RX);
 
-        if (!extension_loaded('intl')) {
+        if (!function_exists('grapheme_strlen')) {
             extension_loaded('iconv') or static::initIconv();
             extension_loaded('mbstring') or static::initMbstring();
 

--- a/patchwork/utf8/src/Patchwork/Utf8/Bootup/iconv.php
+++ b/patchwork/utf8/src/Patchwork/Utf8/Bootup/iconv.php
@@ -16,8 +16,6 @@ const ICONV_VERSION = '1.0';
 const ICONV_MIME_DECODE_STRICT = 1;
 const ICONV_MIME_DECODE_CONTINUE_ON_ERROR = 2;
 
-@trigger_error('You are using a fallback implementation of the iconv extension. Installing the native one is highly recommended instead.', E_USER_DEPRECATED);
-
 function iconv($from, $to, $s) {return s\Iconv::iconv($from, $to, $s);};
 function iconv_get_encoding($type = 'all') {return s\Iconv::iconv_get_encoding($type);};
 function iconv_set_encoding($type, $charset) {return s\Iconv::iconv_set_encoding($type, $charset);};

--- a/patchwork/utf8/src/Patchwork/Utf8/Bootup/intl.php
+++ b/patchwork/utf8/src/Patchwork/Utf8/Bootup/intl.php
@@ -15,8 +15,6 @@ const GRAPHEME_EXTR_COUNT = 0;
 const GRAPHEME_EXTR_MAXBYTES = 1;
 const GRAPHEME_EXTR_MAXCHARS = 2;
 
-@trigger_error('You are using a fallback implementation of the intl extension. Installing the native one is highly recommended instead.', E_USER_DEPRECATED);
-
 function normalizer_is_normalized($s, $form = s\Normalizer::NFC) {return s\Normalizer::isNormalized($s, $form);};
 function normalizer_normalize($s, $form = s\Normalizer::NFC) {return s\Normalizer::normalize($s, $form);};
 

--- a/patchwork/utf8/src/Patchwork/Utf8/Bootup/mbstring.php
+++ b/patchwork/utf8/src/Patchwork/Utf8/Bootup/mbstring.php
@@ -18,8 +18,6 @@ const MB_CASE_UPPER = 0;
 const MB_CASE_LOWER = 1;
 const MB_CASE_TITLE = 2;
 
-@trigger_error('You are using a fallback implementation of the mbstring extension. Installing the native one is highly recommended instead.', E_USER_DEPRECATED);
-
 function mb_convert_encoding($s, $to, $from = INF) {return s\Mbstring::mb_convert_encoding($s, $to, $from);};
 function mb_decode_mimeheader($s) {return s\Mbstring::mb_decode_mimeheader($s);};
 function mb_encode_mimeheader($s, $charset = INF, $transfer_enc = INF, $lf = INF, $indent = INF) {return s\Mbstring::mb_encode_mimeheader($s, $charset, $transfer_enc, $lf, $indent);};

--- a/patchwork/utf8/src/Patchwork/Utf8/Bootup/utf8_encode.php
+++ b/patchwork/utf8/src/Patchwork/Utf8/Bootup/utf8_encode.php
@@ -11,7 +11,5 @@
 
 use Patchwork\PHP\Shim as s;
 
-@trigger_error('You are using a fallback implementation of the xml extension. Installing the native one is highly recommended instead.', E_USER_DEPRECATED);
-
 function utf8_encode($s) {return s\Xml::utf8_encode($s);};
 function utf8_decode($s) {return s\Xml::utf8_decode($s);};


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/22324 and https://github.com/owncloud/core/issues/20065

For 9.1 we should just drop patchwork and use the Symfony polyfills. But for 9.0 this seems to risky so some manual patches :speak_no_evil: :see_no_evil: :hear_no_evil: 

Ref https://github.com/owncloud/core/issues/22442

cc @DeepDiver1975 @PVince81 Mind reviewing?