### PR TITLE
Update to sabre 3.0.8 for fseek fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"deepdiver1975/TarStreamer": "v0.1.0",
 		"patchwork/jsqueeze": "^2.0",
 		"kriswallsmith/assetic": "1.3.2",
-		"sabre/dav": "3.0.7",
+		"sabre/dav": "3.0.8",
 		"symfony/polyfill-php70": "^1.0",
 		"symfony/polyfill-php55": "^1.0",
 		"symfony/polyfill-php56": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -2384,16 +2384,16 @@
         },
         {
             "name": "sabre/uri",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruux/sabre-uri.git",
-                "reference": "6bae7efdd9dfcfdb3edfc4362741e59ce4b64f42"
+                "reference": "9012116434d84ef6e5e37a89dfdbfbe2204a8704"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/6bae7efdd9dfcfdb3edfc4362741e59ce4b64f42",
-                "reference": "6bae7efdd9dfcfdb3edfc4362741e59ce4b64f42",
+                "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/9012116434d84ef6e5e37a89dfdbfbe2204a8704",
+                "reference": "9012116434d84ef6e5e37a89dfdbfbe2204a8704",
                 "shasum": ""
             },
             "require": {
@@ -2431,7 +2431,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2015-04-29 03:47:26"
+            "time": "2016-03-08 02:29:27"
         },
         {
             "name": "sabre/vobject",
@@ -2501,16 +2501,16 @@
         },
         {
             "name": "sabre/xml",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruux/sabre-xml.git",
-                "reference": "420400f36655d79894fae8ce970516a71ea8f5f5"
+                "reference": "59998046db252634259a878baf1af18159f508f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-xml/zipball/420400f36655d79894fae8ce970516a71ea8f5f5",
-                "reference": "420400f36655d79894fae8ce970516a71ea8f5f5",
+                "url": "https://api.github.com/repos/fruux/sabre-xml/zipball/59998046db252634259a878baf1af18159f508f3",
+                "reference": "59998046db252634259a878baf1af18159f508f3",
                 "shasum": ""
             },
             "require": {
@@ -2560,7 +2560,7 @@
                 "dom",
                 "xml"
             ],
-            "time": "2015-12-29 20:51:22"
+            "time": "2016-03-12 22:23:16"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cf4ef9150b818aa24ae4d9f6abfbbd0f",
-    "content-hash": "167e71086ccd474f568b94fa0aa307ea",
+    "hash": "e358b5279a99469a58e2e2137cde62a7",
+    "content-hash": "d71eb9e02d8b6aab2f6f4bf1d9dfc1da",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -2197,16 +2197,16 @@
         },
         {
             "name": "sabre/dav",
-            "version": "3.0.7",
+            "version": "3.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruux/sabre-dav.git",
-                "reference": "294b6e133f3b4cf644b9637a734b53f82d46d7f7"
+                "reference": "69c5080ae689247d06a3c30fba05aba22bb81cf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/294b6e133f3b4cf644b9637a734b53f82d46d7f7",
-                "reference": "294b6e133f3b4cf644b9637a734b53f82d46d7f7",
+                "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/69c5080ae689247d06a3c30fba05aba22bb81cf5",
+                "reference": "69c5080ae689247d06a3c30fba05aba22bb81cf5",
                 "shasum": ""
             },
             "require": {
@@ -2274,7 +2274,7 @@
                 "framework",
                 "iCalendar"
             ],
-            "time": "2016-01-12 22:41:05"
+            "time": "2016-03-12 22:36:59"
         },
         {
             "name": "sabre/event",

--- a/composer/installed.json
+++ b/composer/installed.json
@@ -1430,59 +1430,6 @@
         "description": "A set of generic stream wrappers"
     },
     {
-        "name": "sabre/uri",
-        "version": "1.0.1",
-        "version_normalized": "1.0.1.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/fruux/sabre-uri.git",
-            "reference": "6bae7efdd9dfcfdb3edfc4362741e59ce4b64f42"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/6bae7efdd9dfcfdb3edfc4362741e59ce4b64f42",
-            "reference": "6bae7efdd9dfcfdb3edfc4362741e59ce4b64f42",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.4.7"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "*",
-            "sabre/cs": "~0.0.1"
-        },
-        "time": "2015-04-29 03:47:26",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "files": [
-                "lib/functions.php"
-            ],
-            "psr-4": {
-                "Sabre\\Uri\\": "lib/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "BSD-3-Clause"
-        ],
-        "authors": [
-            {
-                "name": "Evert Pot",
-                "email": "me@evertpot.com",
-                "homepage": "http://evertpot.com/",
-                "role": "Developer"
-            }
-        ],
-        "description": "Functions for making sense out of URIs.",
-        "homepage": "http://sabre.io/uri/",
-        "keywords": [
-            "rfc3986",
-            "uri",
-            "url"
-        ]
-    },
-    {
         "name": "sabre/event",
         "version": "2.0.2",
         "version_normalized": "2.0.2.0",
@@ -2023,71 +1970,6 @@
         "homepage": "https://github.com/fruux/sabre-http",
         "keywords": [
             "http"
-        ]
-    },
-    {
-        "name": "sabre/xml",
-        "version": "1.3.0",
-        "version_normalized": "1.3.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/fruux/sabre-xml.git",
-            "reference": "420400f36655d79894fae8ce970516a71ea8f5f5"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/fruux/sabre-xml/zipball/420400f36655d79894fae8ce970516a71ea8f5f5",
-            "reference": "420400f36655d79894fae8ce970516a71ea8f5f5",
-            "shasum": ""
-        },
-        "require": {
-            "ext-dom": "*",
-            "ext-xmlreader": "*",
-            "ext-xmlwriter": "*",
-            "lib-libxml": ">=2.6.20",
-            "php": ">=5.4.1",
-            "sabre/uri": "~1.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "*",
-            "sabre/cs": "~0.0.2"
-        },
-        "time": "2015-12-29 20:51:22",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Sabre\\Xml\\": "lib/"
-            },
-            "files": [
-                "lib/Deserializer/functions.php",
-                "lib/Serializer/functions.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "BSD-3-Clause"
-        ],
-        "authors": [
-            {
-                "name": "Evert Pot",
-                "email": "me@evertpot.com",
-                "homepage": "http://evertpot.com/",
-                "role": "Developer"
-            },
-            {
-                "name": "Markus Staab",
-                "email": "markus.staab@redaxo.de",
-                "role": "Developer"
-            }
-        ],
-        "description": "sabre/xml is an XML library that you may not hate.",
-        "homepage": "https://sabre.io/xml/",
-        "keywords": [
-            "XMLReader",
-            "XMLWriter",
-            "dom",
-            "xml"
         ]
     },
     {
@@ -3241,6 +3123,124 @@
             "WebDAV",
             "framework",
             "iCalendar"
+        ]
+    },
+    {
+        "name": "sabre/uri",
+        "version": "1.1.0",
+        "version_normalized": "1.1.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/fruux/sabre-uri.git",
+            "reference": "9012116434d84ef6e5e37a89dfdbfbe2204a8704"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/9012116434d84ef6e5e37a89dfdbfbe2204a8704",
+            "reference": "9012116434d84ef6e5e37a89dfdbfbe2204a8704",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.4.7"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "*",
+            "sabre/cs": "~0.0.1"
+        },
+        "time": "2016-03-08 02:29:27",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "files": [
+                "lib/functions.php"
+            ],
+            "psr-4": {
+                "Sabre\\Uri\\": "lib/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Evert Pot",
+                "email": "me@evertpot.com",
+                "homepage": "http://evertpot.com/",
+                "role": "Developer"
+            }
+        ],
+        "description": "Functions for making sense out of URIs.",
+        "homepage": "http://sabre.io/uri/",
+        "keywords": [
+            "rfc3986",
+            "uri",
+            "url"
+        ]
+    },
+    {
+        "name": "sabre/xml",
+        "version": "1.4.1",
+        "version_normalized": "1.4.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/fruux/sabre-xml.git",
+            "reference": "59998046db252634259a878baf1af18159f508f3"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/fruux/sabre-xml/zipball/59998046db252634259a878baf1af18159f508f3",
+            "reference": "59998046db252634259a878baf1af18159f508f3",
+            "shasum": ""
+        },
+        "require": {
+            "ext-dom": "*",
+            "ext-xmlreader": "*",
+            "ext-xmlwriter": "*",
+            "lib-libxml": ">=2.6.20",
+            "php": ">=5.4.1",
+            "sabre/uri": "~1.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "*",
+            "sabre/cs": "~0.0.2"
+        },
+        "time": "2016-03-12 22:23:16",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Sabre\\Xml\\": "lib/"
+            },
+            "files": [
+                "lib/Deserializer/functions.php",
+                "lib/Serializer/functions.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Evert Pot",
+                "email": "me@evertpot.com",
+                "homepage": "http://evertpot.com/",
+                "role": "Developer"
+            },
+            {
+                "name": "Markus Staab",
+                "email": "markus.staab@redaxo.de",
+                "role": "Developer"
+            }
+        ],
+        "description": "sabre/xml is an XML library that you may not hate.",
+        "homepage": "https://sabre.io/xml/",
+        "keywords": [
+            "XMLReader",
+            "XMLWriter",
+            "dom",
+            "xml"
         ]
     }
 ]

--- a/composer/installed.json
+++ b/composer/installed.json
@@ -2221,89 +2221,6 @@
         ]
     },
     {
-        "name": "sabre/dav",
-        "version": "3.0.7",
-        "version_normalized": "3.0.7.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/fruux/sabre-dav.git",
-            "reference": "294b6e133f3b4cf644b9637a734b53f82d46d7f7"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/294b6e133f3b4cf644b9637a734b53f82d46d7f7",
-            "reference": "294b6e133f3b4cf644b9637a734b53f82d46d7f7",
-            "shasum": ""
-        },
-        "require": {
-            "ext-ctype": "*",
-            "ext-date": "*",
-            "ext-dom": "*",
-            "ext-iconv": "*",
-            "ext-libxml": "*",
-            "ext-mbstring": "*",
-            "ext-pcre": "*",
-            "ext-simplexml": "*",
-            "ext-spl": "*",
-            "php": ">=5.4.1",
-            "sabre/event": "~2.0",
-            "sabre/http": "~4.0",
-            "sabre/uri": "~1.0",
-            "sabre/vobject": "^3.3.4",
-            "sabre/xml": "~1.0"
-        },
-        "require-dev": {
-            "evert/phpdoc-md": "~0.1.0",
-            "phpunit/phpunit": "~4.2",
-            "sabre/cs": "~0.0.2"
-        },
-        "suggest": {
-            "ext-curl": "*",
-            "ext-pdo": "*"
-        },
-        "time": "2016-01-12 22:41:05",
-        "bin": [
-            "bin/sabredav",
-            "bin/naturalselection"
-        ],
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "3.0.0-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Sabre\\DAV\\": "lib/DAV/",
-                "Sabre\\DAVACL\\": "lib/DAVACL/",
-                "Sabre\\CalDAV\\": "lib/CalDAV/",
-                "Sabre\\CardDAV\\": "lib/CardDAV/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "BSD-3-Clause"
-        ],
-        "authors": [
-            {
-                "name": "Evert Pot",
-                "email": "me@evertpot.com",
-                "homepage": "http://evertpot.com/",
-                "role": "Developer"
-            }
-        ],
-        "description": "WebDAV Framework for PHP",
-        "homepage": "http://sabre.io/",
-        "keywords": [
-            "CalDAV",
-            "CardDAV",
-            "WebDAV",
-            "framework",
-            "iCalendar"
-        ]
-    },
-    {
         "name": "interfasys/lognormalizer",
         "version": "v1.0",
         "version_normalized": "1.0.0.0",
@@ -3241,6 +3158,89 @@
             "dbal",
             "persistence",
             "queryobject"
+        ]
+    },
+    {
+        "name": "sabre/dav",
+        "version": "3.0.8",
+        "version_normalized": "3.0.8.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/fruux/sabre-dav.git",
+            "reference": "69c5080ae689247d06a3c30fba05aba22bb81cf5"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/69c5080ae689247d06a3c30fba05aba22bb81cf5",
+            "reference": "69c5080ae689247d06a3c30fba05aba22bb81cf5",
+            "shasum": ""
+        },
+        "require": {
+            "ext-ctype": "*",
+            "ext-date": "*",
+            "ext-dom": "*",
+            "ext-iconv": "*",
+            "ext-libxml": "*",
+            "ext-mbstring": "*",
+            "ext-pcre": "*",
+            "ext-simplexml": "*",
+            "ext-spl": "*",
+            "php": ">=5.4.1",
+            "sabre/event": "~2.0",
+            "sabre/http": "~4.0",
+            "sabre/uri": "~1.0",
+            "sabre/vobject": "^3.3.4",
+            "sabre/xml": "~1.0"
+        },
+        "require-dev": {
+            "evert/phpdoc-md": "~0.1.0",
+            "phpunit/phpunit": "~4.2",
+            "sabre/cs": "~0.0.2"
+        },
+        "suggest": {
+            "ext-curl": "*",
+            "ext-pdo": "*"
+        },
+        "time": "2016-03-12 22:36:59",
+        "bin": [
+            "bin/sabredav",
+            "bin/naturalselection"
+        ],
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "3.0.0-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Sabre\\DAV\\": "lib/DAV/",
+                "Sabre\\DAVACL\\": "lib/DAVACL/",
+                "Sabre\\CalDAV\\": "lib/CalDAV/",
+                "Sabre\\CardDAV\\": "lib/CardDAV/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Evert Pot",
+                "email": "me@evertpot.com",
+                "homepage": "http://evertpot.com/",
+                "role": "Developer"
+            }
+        ],
+        "description": "WebDAV Framework for PHP",
+        "homepage": "http://sabre.io/",
+        "keywords": [
+            "CalDAV",
+            "CardDAV",
+            "WebDAV",
+            "framework",
+            "iCalendar"
         ]
     }
 ]

--- a/sabre/dav/CHANGELOG.md
+++ b/sabre/dav/CHANGELOG.md
@@ -1,6 +1,18 @@
 ChangeLog
 =========
 
+3.0.8 (2016-03-12)
+------------------
+
+* #784: Sync logs for address books were not correctly cleaned up after
+  deleting them.
+* #787: Cannot use non-seekable stream-wrappers with range requests.
+* Faster XML parsing and generating due to sabre/xml update.
+* The zip release ships with [sabre/vobject 3.5.0][vobj],
+  [sabre/http 4.2.1][http], [sabre/event 2.0.2][evnt],
+  [sabre/uri 1.1.0][uri] and [sabre/xml 1.4.1][xml].
+
+
 3.0.7 (2016-01-12)
 ------------------
 
@@ -235,6 +247,21 @@ ChangeLog
 * #582: `Sabre\DAV\Auth\Plugin::getCurrentUser()` is now deprecated. Use
   `Sabre\DAV\Auth\Plugin::getCurrentPrincipal()` instead.
 * #193: Fix `Sabre\DAV\FSExt\Directory::getQuotaInfo()` on windows.
+
+
+2.1.10 (2016-03-10)
+-------------------
+
+* #784: Sync logs for address books were not correctly cleaned up after
+  deleting them.
+
+
+2.1.9 (2016-01-25)
+------------------
+
+* #674: PHP7 support (@DeepDiver1975).
+* The zip release ships with [sabre/vobject 3.5.0][vobj],
+  [sabre/http 3.0.5][http], and [sabre/event 2.0.2][evnt].
 
 
 2.1.8 (2016-01-04)

--- a/sabre/dav/lib/CardDAV/Backend/PDO.php
+++ b/sabre/dav/lib/CardDAV/Backend/PDO.php
@@ -198,7 +198,7 @@ class PDO extends AbstractBackend implements SyncSupport {
         $stmt = $this->pdo->prepare('DELETE FROM ' . $this->addressBooksTableName . ' WHERE id = ?');
         $stmt->execute([$addressBookId]);
 
-        $stmt = $this->pdo->prepare('DELETE FROM ' . $this->addressBookChangesTableName . ' WHERE id = ?');
+        $stmt = $this->pdo->prepare('DELETE FROM ' . $this->addressBookChangesTableName . ' WHERE addressbookid = ?');
         $stmt->execute([$addressBookId]);
 
     }

--- a/sabre/dav/lib/DAV/CorePlugin.php
+++ b/sabre/dav/lib/DAV/CorePlugin.php
@@ -169,12 +169,10 @@ class CorePlugin extends ServerPlugin {
 
             }
 
-            // for a seekable $body stream we simply set the pointer
-            // for a non-seekable $body stream we read and discard just the
-            // right amount of data
-            if (stream_get_meta_data($body)['seekable']) {
-                fseek($body, $start, SEEK_SET);
-            } else {
+            // Streams may advertise themselves as seekable, but still not
+            // actually allow fseek.  We'll manually go forward in the stream
+            // if fseek failed.
+            if (!stream_get_meta_data($body)['seekable'] || fseek($body, $start, SEEK_SET) === -1) {
                 $consumeBlock = 8192;
                 for ($consumed = 0; $start - $consumed > 0;){
                     if (feof($body)) throw new Exception\RequestedRangeNotSatisfiable('The start offset (' . $start . ') exceeded the size of the entity (' . $consumed . ')');

--- a/sabre/dav/lib/DAV/Version.php
+++ b/sabre/dav/lib/DAV/Version.php
@@ -14,6 +14,6 @@ class Version {
     /**
      * Full version number
      */
-    const VERSION = '3.0.7';
+    const VERSION = '3.0.8';
 
 }

--- a/sabre/uri/CHANGELOG.md
+++ b/sabre/uri/CHANGELOG.md
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+1.1.0 (2016-03-07)
+------------------
+
+* #6: PHP's `parse_url()` corrupts strings if they contain certain
+  non ascii-characters such as Chinese or Hebrew. sabre/uri's `parse()`
+  function now percent-encodes these characters beforehand.
+
+
 1.0.1 (2015-04-28)
 ------------------
 

--- a/sabre/uri/LICENSE
+++ b/sabre/uri/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2014-2015 fruux GmbH (https://fruux.com/)
+Copyright (C) 2014-2016 fruux GmbH (https://fruux.com/)
 
 All rights reserved.
 

--- a/sabre/uri/lib/Version.php
+++ b/sabre/uri/lib/Version.php
@@ -5,7 +5,7 @@ namespace Sabre\Uri;
 /**
  * This class contains the version number for this package.
  *
- * @copyright Copyright (C) 2014-2015 fruux GmbH (https://fruux.com/).
+ * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/
  */
@@ -14,6 +14,6 @@ class Version {
     /**
      * Full version number
      */
-    const VERSION = '1.0.1';
+    const VERSION = '1.1.0';
 
 }

--- a/sabre/uri/lib/functions.php
+++ b/sabre/uri/lib/functions.php
@@ -3,6 +3,14 @@
 namespace Sabre\Uri;
 
 /**
+ * This file contains all the uri handling functions.
+ *
+ * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/
+ */
+
+/**
  * Resolves relative urls, like a browser would.
  *
  * This function takes a basePath, which itself _may_ also be relative, and
@@ -25,7 +33,7 @@ function resolve($basePath, $newPath) {
             return $base[$part];
         }
         return null;
-        
+
     };
 
     // If the new path defines a scheme, it's absolute and we can just return
@@ -59,9 +67,9 @@ function resolve($basePath, $newPath) {
     // Removing .. and .
     $pathParts = explode('/', $path);
     $newPathParts = [];
-    foreach($pathParts as $pathPart) {
+    foreach ($pathParts as $pathPart) {
 
-        switch($pathPart) {
+        switch ($pathPart) {
             //case '' :
             case '.' :
                 break;
@@ -110,8 +118,8 @@ function normalize($uri) {
     if (!empty($parts['path'])) {
         $pathParts = explode('/', ltrim($parts['path'], '/'));
         $newPathParts = [];
-        foreach($pathParts as $pathPart) {
-            switch($pathPart) {
+        foreach ($pathParts as $pathPart) {
+            switch ($pathPart) {
                 case '.':
                     // skip
                     break;
@@ -140,7 +148,7 @@ function normalize($uri) {
             unset($parts['port']);
         }
         // A few HTTP specific rules.
-        switch($parts['scheme']) {
+        switch ($parts['scheme']) {
             case 'http' :
             case 'https' :
                 if (empty($parts['path'])) {
@@ -164,10 +172,26 @@ function normalize($uri) {
  * return an array with all the array keys, including the ones that are not
  * set by parse_url, which makes it a bit easier to work with.
  *
+ * Unlike PHP's parse_url, it will also convert any non-ascii characters to
+ * percent-encoded strings. PHP's parse_url corrupts these characters on OS X.
+ *
  * @param string $uri
  * @return array
  */
 function parse($uri) {
+
+    // Normally a URI must be ASCII, however. However, often it's not and
+    // parse_url might corrupt these strings.
+    //
+    // For that reason we take any non-ascii characters from the uri and
+    // uriencode them first.
+    $uri = preg_replace_callback(
+        '/[^[:ascii:]]/u',
+        function($matches) {
+            return rawurlencode($matches[0]);
+        },
+        $uri
+    );
 
     return
         parse_url($uri) + [
@@ -250,9 +274,9 @@ function build(array $parts) {
 function split($path) {
 
     $matches = [];
-    if(preg_match('/^(?:(?:(.*)(?:\/+))?([^\/]+))(?:\/?)$/u', $path, $matches)) {
+    if (preg_match('/^(?:(?:(.*)(?:\/+))?([^\/]+))(?:\/?)$/u', $path, $matches)) {
         return [$matches[1], $matches[2]];
     }
     return [null,null];
-    
+
 }

--- a/sabre/uri/tests/NormalizeTest.php
+++ b/sabre/uri/tests/NormalizeTest.php
@@ -31,6 +31,9 @@ class NormalizeTest extends \PHPUnit_Framework_TestCase{
             [ 'http://example.org',              'http://example.org/'],
             [ 'http://example.org:/',            'http://example.org/'],
             [ 'http://example.org:80/',          'http://example.org/'],
+            // See issue #6. parse_url corrupts strings like this, but only on
+            // macs.
+            //[ 'http://example.org/有词法别名.zh','http://example.org/%E6%9C%89%E8%AF%8D%E6%B3%95%E5%88%AB%E5%90%8D.zh'],
 
         ];
 

--- a/sabre/xml/CHANGELOG.md
+++ b/sabre/xml/CHANGELOG.md
@@ -1,6 +1,25 @@
 ChangeLog
 =========
 
+1.4.1 (2016-03-12)
+-----------------
+
+* Parsing clark-notation is now cached. This can speed up parsing large
+  documents with lots of repeating elements a fair bit. (@icewind1991).
+
+
+1.4.0 (2016-02-14)
+------------------
+
+* Any array thrown into the serializer with numeric keys is now simply
+  traversed and each individual item is serialized. This fixes an issue
+  related to serializing value objects with array children.
+* When serializing value objects, properties that have a null value or an
+  empty array are now skipped. We believe this to be the saner default, but
+  does constitute a BC break for those depending on this.
+* Serializing array properties in value objects was broken.
+
+
 1.3.0 (2015-12-29)
 ------------------
 

--- a/sabre/xml/lib/Serializer/functions.php
+++ b/sabre/xml/lib/Serializer/functions.php
@@ -51,13 +51,25 @@ function enum(Writer $writer, array $values) {
  * Every public property will be encoded as an xml element with the same
  * name, in the XML namespace as specified.
  *
+ * Values that are set to null or an empty array are not serialized. To
+ * serialize empty properties, you must specify them as an empty string.
+ *
  * @param Writer $writer
  * @param object $valueObject
  * @param string $namespace
  */
 function valueObject(Writer $writer, $valueObject, $namespace) {
     foreach (get_object_vars($valueObject) as $key => $val) {
-        $writer->writeElement('{' . $namespace . '}' . $key, $val);
+        if (is_array($val)) {
+            // If $val is an array, it has a special meaning. We need to
+            // generate one child element for each item in $val
+            foreach ($val as $child) {
+                $writer->writeElement('{' . $namespace . '}' . $key, $child);
+            }
+
+        } elseif ($val !== null) {
+            $writer->writeElement('{' . $namespace . '}' . $key, $val);
+        }
     }
 }
 
@@ -80,7 +92,7 @@ function valueObject(Writer $writer, $valueObject, $namespace) {
  * @param Writer $writer
  * @param array $items A list of items sabre/xml can serialize.
  * @param string $childElementName Element name in clark-notation
- * @return array
+ * @return void
  */
 function repeatingElements(Writer $writer, array $items, $childElementName) {
 
@@ -175,39 +187,53 @@ function standardSerializer(Writer $writer, $value) {
 
         // nothing!
 
+    } elseif (is_array($value) && array_key_exists('name', $value)) {
+
+        // if the array had a 'name' element, we assume that this array
+        // describes a 'name' and optionally 'attributes' and 'value'.
+
+        $name = $value['name'];
+        $attributes = isset($value['attributes']) ? $value['attributes'] : [];
+        $value = isset($value['value']) ? $value['value'] : null;
+
+        $writer->startElement($name);
+        $writer->writeAttributes($attributes);
+        $writer->write($value);
+        $writer->endElement();
+
     } elseif (is_array($value)) {
 
         foreach ($value as $name => $item) {
 
             if (is_int($name)) {
 
-                // This item has a numeric index. We expect to be an array with a name and a value.
-                if (!is_array($item) || !array_key_exists('name', $item)) {
-                    throw new InvalidArgumentException('When passing an array to ->write with numeric indices, every item must be an array containing at least the "name" key');
+                // This item has a numeric index. We just loop through the
+                // array and throw it back in the writer.
+                standardSerializer($writer, $item);
+
+            } elseif (is_string($name) && is_array($item) && isset($item['attributes'])) {
+
+                // The key is used for a name, but $item has 'attributes' and
+                // possibly 'value'
+                $writer->startElement($name);
+                $writer->writeAttributes($item['attributes']);
+                if (isset($item['value'])) {
+                    $writer->write($item['value']);
                 }
+                $writer->endElement();
 
-                $attributes = isset($item['attributes']) ? $item['attributes'] : [];
-                $name = $item['name'];
-                $item = isset($item['value']) ? $item['value'] : [];
+            } elseif (is_string($name)) {
 
-            } elseif (is_array($item) && array_key_exists('value', $item)) {
-
-                // This item has a text index. We expect to be an array with a value and optional attributes.
-                $attributes = isset($item['attributes']) ? $item['attributes'] : [];
-                $item = $item['value'];
+                // This was a plain key-value array.
+                $writer->startElement($name);
+                $writer->write($item);
+                $writer->endElement();
 
             } else {
-                // If it's an array with text-indices, we expect every item's
-                // key to be an xml element name in clark notation.
-                // No attributes can be passed.
-                $attributes = [];
+
+                throw new InvalidArgumentException('The writer does not know how to serialize arrays with keys of type: ' . gettype($name));
+
             }
-
-            $writer->startElement($name);
-            $writer->writeAttributes($attributes);
-            $writer->write($item);
-            $writer->endElement();
-
         }
 
     } elseif (is_object($value)) {

--- a/sabre/xml/lib/Service.php
+++ b/sabre/xml/lib/Service.php
@@ -266,16 +266,21 @@ class Service {
      * @return array
      */
     static function parseClarkNotation($str) {
+        static $cache = [];
 
-        if (!preg_match('/^{([^}]*)}(.*)$/', $str, $matches)) {
-            throw new \InvalidArgumentException('\'' . $str . '\' is not a valid clark-notation formatted string');
+        if (!isset($cache[$str])) {
+
+            if (!preg_match('/^{([^}]*)}(.*)$/', $str, $matches)) {
+                throw new \InvalidArgumentException('\'' . $str . '\' is not a valid clark-notation formatted string');
+            }
+
+            $cache[$str] = [
+                $matches[1],
+                $matches[2]
+            ];
         }
 
-        return [
-            $matches[1],
-            $matches[2]
-        ];
-
+        return $cache[$str];
     }
 
     /**

--- a/sabre/xml/lib/Version.php
+++ b/sabre/xml/lib/Version.php
@@ -14,6 +14,6 @@ class Version {
     /**
      * Full version number
      */
-    const VERSION = '1.3.0';
+    const VERSION = '1.4.1';
 
 }


### PR DESCRIPTION
Fix for https://github.com/owncloud/core/issues/22476#issuecomment-196764305

@DeepDiver1975 @icewind1991 @rullzer @nickvergessen

@karlitschek backport to 9.0.1 ? This library update fixes issues with range requests when using external storage or federated shares (https). Range requests are used by the sync client when resuming aborted big downloads.

The bug itself is bad because it returns the **wrong** bytes when fseek fails.