### PR TITLE
[stable9] Update to sabre 3.0.8 for fseek regression fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"deepdiver1975/TarStreamer": "v0.1.0",
 		"patchwork/jsqueeze": "^2.0",
 		"kriswallsmith/assetic": "1.3.2",
-		"sabre/dav": "3.0.7",
+		"sabre/dav": "3.0.8",
 		"symfony/polyfill-php70": "^1.0",
 		"symfony/polyfill-php55": "^1.0",
 		"symfony/polyfill-php56": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "01a2beb82c7d1d41a162c7a0d4f92d67",
-    "content-hash": "513a3dea6f9343315cafeff57cd53ad6",
+    "hash": "16f3f116d8f04eba749f3e04aea6d6ed",
+    "content-hash": "57cd9e973a955d09821258794c6bd968",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1145,7 +1145,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JamesHeinrich/getID3/zipball/087b7270a6cff16f32a66bcb6af58866ad19dd07",
+                "url": "https://api.github.com/repos/JamesHeinrich/getID3/zipball/5c85d440b6c7d5ffdc4b8d8d6fdd37c6e244b3af",
                 "reference": "afbdaa044a9a0a9dff2f800bd670e231b3ec99b2",
                 "shasum": ""
             },
@@ -2197,16 +2197,16 @@
         },
         {
             "name": "sabre/dav",
-            "version": "3.0.7",
+            "version": "3.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruux/sabre-dav.git",
-                "reference": "294b6e133f3b4cf644b9637a734b53f82d46d7f7"
+                "reference": "69c5080ae689247d06a3c30fba05aba22bb81cf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/294b6e133f3b4cf644b9637a734b53f82d46d7f7",
-                "reference": "294b6e133f3b4cf644b9637a734b53f82d46d7f7",
+                "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/69c5080ae689247d06a3c30fba05aba22bb81cf5",
+                "reference": "69c5080ae689247d06a3c30fba05aba22bb81cf5",
                 "shasum": ""
             },
             "require": {
@@ -2274,7 +2274,7 @@
                 "framework",
                 "iCalendar"
             ],
-            "time": "2016-01-12 22:41:05"
+            "time": "2016-03-12 22:36:59"
         },
         {
             "name": "sabre/event",

--- a/composer/installed.json
+++ b/composer/installed.json
@@ -350,7 +350,7 @@
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/JamesHeinrich/getID3/zipball/087b7270a6cff16f32a66bcb6af58866ad19dd07",
+            "url": "https://api.github.com/repos/JamesHeinrich/getID3/zipball/5c85d440b6c7d5ffdc4b8d8d6fdd37c6e244b3af",
             "reference": "afbdaa044a9a0a9dff2f800bd670e231b3ec99b2",
             "shasum": ""
         },
@@ -2672,89 +2672,6 @@
         ]
     },
     {
-        "name": "sabre/dav",
-        "version": "3.0.7",
-        "version_normalized": "3.0.7.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/fruux/sabre-dav.git",
-            "reference": "294b6e133f3b4cf644b9637a734b53f82d46d7f7"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/294b6e133f3b4cf644b9637a734b53f82d46d7f7",
-            "reference": "294b6e133f3b4cf644b9637a734b53f82d46d7f7",
-            "shasum": ""
-        },
-        "require": {
-            "ext-ctype": "*",
-            "ext-date": "*",
-            "ext-dom": "*",
-            "ext-iconv": "*",
-            "ext-libxml": "*",
-            "ext-mbstring": "*",
-            "ext-pcre": "*",
-            "ext-simplexml": "*",
-            "ext-spl": "*",
-            "php": ">=5.4.1",
-            "sabre/event": "~2.0",
-            "sabre/http": "~4.0",
-            "sabre/uri": "~1.0",
-            "sabre/vobject": "^3.3.4",
-            "sabre/xml": "~1.0"
-        },
-        "require-dev": {
-            "evert/phpdoc-md": "~0.1.0",
-            "phpunit/phpunit": "~4.2",
-            "sabre/cs": "~0.0.2"
-        },
-        "suggest": {
-            "ext-curl": "*",
-            "ext-pdo": "*"
-        },
-        "time": "2016-01-12 22:41:05",
-        "bin": [
-            "bin/sabredav",
-            "bin/naturalselection"
-        ],
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "3.0.0-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Sabre\\DAV\\": "lib/DAV/",
-                "Sabre\\DAVACL\\": "lib/DAVACL/",
-                "Sabre\\CalDAV\\": "lib/CalDAV/",
-                "Sabre\\CardDAV\\": "lib/CardDAV/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "BSD-3-Clause"
-        ],
-        "authors": [
-            {
-                "name": "Evert Pot",
-                "email": "me@evertpot.com",
-                "homepage": "http://evertpot.com/",
-                "role": "Developer"
-            }
-        ],
-        "description": "WebDAV Framework for PHP",
-        "homepage": "http://sabre.io/",
-        "keywords": [
-            "CalDAV",
-            "CardDAV",
-            "WebDAV",
-            "framework",
-            "iCalendar"
-        ]
-    },
-    {
         "name": "symfony/console",
         "version": "v2.8.1",
         "version_normalized": "2.8.1.0",
@@ -3241,6 +3158,89 @@
         "keywords": [
             "stream",
             "zip"
+        ]
+    },
+    {
+        "name": "sabre/dav",
+        "version": "3.0.8",
+        "version_normalized": "3.0.8.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/fruux/sabre-dav.git",
+            "reference": "69c5080ae689247d06a3c30fba05aba22bb81cf5"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/69c5080ae689247d06a3c30fba05aba22bb81cf5",
+            "reference": "69c5080ae689247d06a3c30fba05aba22bb81cf5",
+            "shasum": ""
+        },
+        "require": {
+            "ext-ctype": "*",
+            "ext-date": "*",
+            "ext-dom": "*",
+            "ext-iconv": "*",
+            "ext-libxml": "*",
+            "ext-mbstring": "*",
+            "ext-pcre": "*",
+            "ext-simplexml": "*",
+            "ext-spl": "*",
+            "php": ">=5.4.1",
+            "sabre/event": "~2.0",
+            "sabre/http": "~4.0",
+            "sabre/uri": "~1.0",
+            "sabre/vobject": "^3.3.4",
+            "sabre/xml": "~1.0"
+        },
+        "require-dev": {
+            "evert/phpdoc-md": "~0.1.0",
+            "phpunit/phpunit": "~4.2",
+            "sabre/cs": "~0.0.2"
+        },
+        "suggest": {
+            "ext-curl": "*",
+            "ext-pdo": "*"
+        },
+        "time": "2016-03-12 22:36:59",
+        "bin": [
+            "bin/sabredav",
+            "bin/naturalselection"
+        ],
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "3.0.0-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Sabre\\DAV\\": "lib/DAV/",
+                "Sabre\\DAVACL\\": "lib/DAVACL/",
+                "Sabre\\CalDAV\\": "lib/CalDAV/",
+                "Sabre\\CardDAV\\": "lib/CardDAV/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Evert Pot",
+                "email": "me@evertpot.com",
+                "homepage": "http://evertpot.com/",
+                "role": "Developer"
+            }
+        ],
+        "description": "WebDAV Framework for PHP",
+        "homepage": "http://sabre.io/",
+        "keywords": [
+            "CalDAV",
+            "CardDAV",
+            "WebDAV",
+            "framework",
+            "iCalendar"
         ]
     }
 ]

--- a/sabre/dav/CHANGELOG.md
+++ b/sabre/dav/CHANGELOG.md
@@ -1,6 +1,18 @@
 ChangeLog
 =========
 
+3.0.8 (2016-03-12)
+------------------
+
+* #784: Sync logs for address books were not correctly cleaned up after
+  deleting them.
+* #787: Cannot use non-seekable stream-wrappers with range requests.
+* Faster XML parsing and generating due to sabre/xml update.
+* The zip release ships with [sabre/vobject 3.5.0][vobj],
+  [sabre/http 4.2.1][http], [sabre/event 2.0.2][evnt],
+  [sabre/uri 1.1.0][uri] and [sabre/xml 1.4.1][xml].
+
+
 3.0.7 (2016-01-12)
 ------------------
 
@@ -235,6 +247,21 @@ ChangeLog
 * #582: `Sabre\DAV\Auth\Plugin::getCurrentUser()` is now deprecated. Use
   `Sabre\DAV\Auth\Plugin::getCurrentPrincipal()` instead.
 * #193: Fix `Sabre\DAV\FSExt\Directory::getQuotaInfo()` on windows.
+
+
+2.1.10 (2016-03-10)
+-------------------
+
+* #784: Sync logs for address books were not correctly cleaned up after
+  deleting them.
+
+
+2.1.9 (2016-01-25)
+------------------
+
+* #674: PHP7 support (@DeepDiver1975).
+* The zip release ships with [sabre/vobject 3.5.0][vobj],
+  [sabre/http 3.0.5][http], and [sabre/event 2.0.2][evnt].
 
 
 2.1.8 (2016-01-04)

--- a/sabre/dav/lib/CardDAV/Backend/PDO.php
+++ b/sabre/dav/lib/CardDAV/Backend/PDO.php
@@ -198,7 +198,7 @@ class PDO extends AbstractBackend implements SyncSupport {
         $stmt = $this->pdo->prepare('DELETE FROM ' . $this->addressBooksTableName . ' WHERE id = ?');
         $stmt->execute([$addressBookId]);
 
-        $stmt = $this->pdo->prepare('DELETE FROM ' . $this->addressBookChangesTableName . ' WHERE id = ?');
+        $stmt = $this->pdo->prepare('DELETE FROM ' . $this->addressBookChangesTableName . ' WHERE addressbookid = ?');
         $stmt->execute([$addressBookId]);
 
     }

--- a/sabre/dav/lib/DAV/CorePlugin.php
+++ b/sabre/dav/lib/DAV/CorePlugin.php
@@ -169,12 +169,10 @@ class CorePlugin extends ServerPlugin {
 
             }
 
-            // for a seekable $body stream we simply set the pointer
-            // for a non-seekable $body stream we read and discard just the
-            // right amount of data
-            if (stream_get_meta_data($body)['seekable']) {
-                fseek($body, $start, SEEK_SET);
-            } else {
+            // Streams may advertise themselves as seekable, but still not
+            // actually allow fseek.  We'll manually go forward in the stream
+            // if fseek failed.
+            if (!stream_get_meta_data($body)['seekable'] || fseek($body, $start, SEEK_SET) === -1) {
                 $consumeBlock = 8192;
                 for ($consumed = 0; $start - $consumed > 0;){
                     if (feof($body)) throw new Exception\RequestedRangeNotSatisfiable('The start offset (' . $start . ') exceeded the size of the entity (' . $consumed . ')');

--- a/sabre/dav/lib/DAV/Version.php
+++ b/sabre/dav/lib/DAV/Version.php
@@ -14,6 +14,6 @@ class Version {
     /**
      * Full version number
      */
-    const VERSION = '3.0.7';
+    const VERSION = '3.0.8';
 
 }


### PR DESCRIPTION
Not a direct backport of https://github.com/owncloud/3rdparty/pull/258 due to composer file conflicts.
So I ran this:
```
± % composer update sabre/dav
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Removing sabre/dav (3.0.7)
  - Installing sabre/dav (3.0.8)
    Loading from cache

Writing lock file
Generating optimized autoload files
```

It does NOT update sabre/xml and other deps.

Please review @DeepDiver1975 @icewind1991 

- [x] backport approval pending https://github.com/owncloud/3rdparty/pull/258#issue-140939717 @karlitschek