### PR TITLE
[debug] Only call fclose callback once

### DIFF
--- a/icewind/streams/src/CallbackWrapper.php
+++ b/icewind/streams/src/CallbackWrapper.php
@@ -107,6 +107,7 @@ class CallbackWrapper extends Wrapper {
 		$result = parent::stream_close();
 		if (is_callable($this->closeCallback)) {
 			call_user_func($this->closeCallback);
+			$this->closeCallback = null;
 		}
 		return $result;
 	}


### PR DESCRIPTION
In some weird cases it seems the GC would call it again